### PR TITLE
公開中の勢いボードと安定作品URL

### DIFF
--- a/.github/workflows/publish-static-site.yml
+++ b/.github/workflows/publish-static-site.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0,6,12,18 * * *'
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: publish-static-site
@@ -47,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -89,6 +91,18 @@ jobs:
         run: |
           php artisan movies:fetch-japanese-boxoffice
           php artisan movies:fetch-global-boxoffice
+
+      - name: Persist box office history
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/history
+          if git diff --cached --quiet; then
+            echo "No box office history changes"
+          else
+            git commit -m "chore: record box office observations"
+            git push
+          fi
 
       - name: Export static site
         run: php artisan site:export-static

--- a/app/Console/Commands/ExportStaticSite.php
+++ b/app/Console/Commands/ExportStaticSite.php
@@ -5,6 +5,9 @@ namespace App\Console\Commands;
 use App\Console\Traits\FetchesTmdbMovieDetails;
 use App\Models\GlobalMovie;
 use App\Models\JapaneseMovie;
+use App\Services\BoxOffice\HistoryRecorder;
+use App\Services\BoxOffice\Insights;
+use App\Services\BoxOffice\MovieIdentity;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -34,9 +37,15 @@ class ExportStaticSite extends Command
         $this->exportMovieDetails($japanModels, $output . '/data/details', $refreshDetails);
 
         $global = $globalModels->values()
-            ->map(fn (GlobalMovie $movie, int $index) => $this->movieData($movie, $index + 1, false));
+            ->map(fn (GlobalMovie $movie, int $index) => $this->movieData($movie, $index + 1, false))
+            ->all();
         $japan = $japanModels->values()
-            ->map(fn (JapaneseMovie $movie, int $index) => $this->movieData($movie, $index + 1, true));
+            ->map(fn (JapaneseMovie $movie, int $index) => $this->movieData($movie, $index + 1, true))
+            ->all();
+
+        $history = HistoryRecorder::fromBasePath(base_path('data/history'));
+        [$global, $globalInsights] = $this->attachInsights('global', $global, $history);
+        [$japan, $japanInsights] = $this->attachInsights('japan', $japan, $history);
 
         File::put($output . '/data/movies.json', json_encode([
             'generatedAt' => now('Asia/Tokyo')->toIso8601String(),
@@ -46,16 +55,26 @@ class ExportStaticSite extends Command
             'japan' => $japan,
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
 
+        $this->exportNowPlaying($output, $global, $japan, $globalInsights, $japanInsights);
+        $this->exportRedirects($output, $history);
+        $this->exportLegacyMap($output, $history);
+        $this->exportFeed($output, $globalInsights, $japanInsights);
+
         $this->copyPublicAssets($output);
         $this->exportRobotsTxt($output);
-        $this->exportMoviePages($output, $global, $japan);
+        $boardOnly = $this->boardOnlyMovies($globalInsights, $japanInsights, $global, $japan);
+        $this->exportMoviePages($output, collect($global), collect($japan));
+        foreach ($boardOnly as $movie) {
+            $this->writeMoviePage($output, $movie, ($movie['region'] ?? '') === 'japan');
+        }
         $this->exportTrustPages($output);
-        $this->exportSitemap($output, $globalModels, $japanModels);
+        $this->exportNowPage($output);
+        $this->exportSitemap($output, $global, $japan, $boardOnly);
         File::put($output . '/index.html', $this->indexHtml());
 
-        $moviePageCount = $global->count() + $japan->count();
+        $moviePageCount = count($global) + count($japan) + count($boardOnly);
         $this->info("Static site exported to {$output}");
-        $this->line("Global: {$global->count()} movies / Japan: {$japan->count()} movies");
+        $this->line("Global: ".count($global)." movies / Japan: ".count($japan)." movies");
         $this->line("Movie pages: {$moviePageCount}");
 
         return self::SUCCESS;
@@ -120,9 +139,10 @@ class ExportStaticSite extends Command
             fn (string $genre) => $this->genreMap()[$genre] ?? $genre,
             $rawGenres,
         ));
-        $isActive = $isJapan
-            ? (bool) $movie->is_active
-            : ($releaseDate && Carbon::parse($releaseDate)->greaterThanOrEqualTo(now()->subMonths(6)));
+        $isActive = (bool) $movie->is_active;
+        if (! $isJapan && ! $movie->is_active && $releaseDate) {
+            $isActive = Carbon::parse($releaseDate)->greaterThanOrEqualTo(now('Asia/Tokyo')->subMonths(6));
+        }
 
         $revenueBillion = $isJapan
             ? number_format($movie->box_office / 100000000, 1)
@@ -133,12 +153,14 @@ class ExportStaticSite extends Command
 
         return [
             'id' => $movie->movie_id,
+            'slug' => $movie->movie_id,
             'tmdbId' => $movie->tmdb_id,
             'rank' => $rank,
             'title' => $title,
             'originalTitle' => $movie->original_title,
             'releaseDate' => $releaseDate,
             'releaseYear' => $releaseDate ? (int) substr($releaseDate, 0, 4) : null,
+            'releaseDatePrecision' => $movie->release_date_precision ?? null,
             'genres' => array_values($genres),
             'posterUrl' => $poster,
             'isActive' => $isActive,
@@ -226,11 +248,272 @@ TXT);
 
     private function movieSlug(string $movieId): string
     {
-        if (str_starts_with($movieId, 'global_')) {
-            return str_replace('global_', '', $movieId);
+        return $movieId;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $movies
+     * @return array{0: list<array<string, mixed>>, 1: array<string, mixed>}
+     */
+    private function attachInsights(string $region, array $movies, HistoryRecorder $history): array
+    {
+        $current = array_map(fn (array $movie) => [
+            'key' => $movie['id'],
+            'title' => $movie['title'],
+            'boxOffice' => $movie['boxOffice'],
+            'isActive' => $movie['isActive'],
+            'rank' => $movie['rank'],
+            'releaseDate' => $movie['releaseDate'],
+            'releaseDatePrecision' => $movie['releaseDatePrecision'] ?? null,
+            'posterUrl' => $movie['posterUrl'] ?? null,
+            'revenue' => $movie['revenue'] ?? null,
+        ], $movies);
+
+        $computed = Insights::compute(
+            $region,
+            $current,
+            $history->observations()->loadByKey($region),
+            $history->registry()->movies(),
+            now('Asia/Tokyo')->toDateTimeImmutable(),
+        );
+
+        foreach ($movies as $index => $movie) {
+            $insight = $computed['movies'][$movie['id']] ?? null;
+            if (! $insight) {
+                continue;
+            }
+            $movies[$index]['momentum'] = [
+                'delta' => $insight['delta'],
+                'deltaLabel' => $insight['deltaLabel'],
+                'daysSincePrev' => $insight['daysSincePrev'],
+                'dailyPaceLabel' => $insight['dailyPaceLabel'],
+                'rankDelta' => $insight['rankDelta'],
+                'rankDeltaLabel' => $insight['rankDeltaLabel'],
+                'passedLabel' => $insight['passedLabel'],
+                'hasHistory' => $insight['hasHistory'],
+                'daysSinceRelease' => $insight['daysSinceRelease'],
+            ];
         }
 
-        return $movieId;
+        foreach (['board', 'today', 'milestones'] as $bucket) {
+            $computed[$bucket] = array_map(function (array $item) use ($movies) {
+                $movie = collect($movies)->firstWhere('id', $item['key']) ?? [];
+                return array_merge($item, [
+                    'posterUrl' => $movie['posterUrl'] ?? null,
+                    'slug' => $item['key'],
+                    'revenue' => $movie['revenue'] ?? ($item['revenueLabel'] ?? null),
+                ]);
+            }, $computed[$bucket]);
+        }
+
+        return [$movies, $computed];
+    }
+
+    /**
+     * @param  array<string, mixed>  $globalInsights
+     * @param  array<string, mixed>  $japanInsights
+     * @param  list<array<string, mixed>>  $global
+     * @param  list<array<string, mixed>>  $japan
+     * @return list<array<string, mixed>>
+     */
+    private function boardOnlyMovies(array $globalInsights, array $japanInsights, array $global, array $japan): array
+    {
+        $known = [];
+        foreach (array_merge($global, $japan) as $movie) {
+            $known[$movie['id']] = true;
+        }
+
+        $extra = [];
+        foreach (['global' => $globalInsights['board'] ?? [], 'japan' => $japanInsights['board'] ?? []] as $region => $board) {
+            foreach ($board as $item) {
+                $key = $item['key'] ?? null;
+                if (! $key || isset($known[$key])) {
+                    continue;
+                }
+                $known[$key] = true;
+                $isJapan = $region === 'japan';
+                $extra[] = [
+                    'id' => $key,
+                    'slug' => $key,
+                    'title' => $item['title'] ?? $key,
+                    'originalTitle' => null,
+                    'rank' => $item['rank'] ?: '圏外',
+                    'releaseDate' => $item['releaseDate'] ?? null,
+                    'releaseDatePrecision' => $item['releaseDatePrecision'] ?? null,
+                    'genres' => [],
+                    'posterUrl' => $item['posterUrl'] ?? null,
+                    'boxOffice' => $item['boxOffice'] ?? 0,
+                    'revenue' => $item['revenueLabel'] ?? ($item['revenue'] ?? ''),
+                    'revenueYen' => null,
+                    'region' => $region,
+                    'momentum' => [
+                        'delta' => $item['delta'] ?? null,
+                        'deltaLabel' => $item['deltaLabel'] ?? null,
+                        'daysSincePrev' => $item['daysSincePrev'] ?? null,
+                        'dailyPaceLabel' => $item['dailyPaceLabel'] ?? null,
+                        'rankDelta' => $item['rankDelta'] ?? null,
+                        'rankDeltaLabel' => $item['rankDeltaLabel'] ?? null,
+                        'passedLabel' => $item['passedLabel'] ?? null,
+                        'hasHistory' => $item['hasHistory'] ?? false,
+                        'daysSinceRelease' => $item['daysSinceRelease'] ?? null,
+                    ],
+                ];
+            }
+        }
+
+        return $extra;
+    }
+
+    private function exportNowPlaying(string $output, array $global, array $japan, array $globalInsights, array $japanInsights): void
+    {
+        File::put($output . '/data/now-playing.json', json_encode([
+            'generatedAt' => now('Asia/Tokyo')->toIso8601String(),
+            'disclaimer' => '日本の興行収入は配給会社の発表ベースです。数字は毎日は動きません。伸びは前回の発表との差です。',
+            'japanLastUpdated' => $this->maxLastUpdated(JapaneseMovie::class),
+            'globalLastUpdated' => $this->maxLastUpdated(GlobalMovie::class),
+            'japan' => [
+                'board' => $japanInsights['board'],
+                'today' => $japanInsights['today'],
+                'milestones' => $japanInsights['milestones'],
+            ],
+            'global' => [
+                'board' => $globalInsights['board'],
+                'today' => $globalInsights['today'],
+                'milestones' => $globalInsights['milestones'],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+    }
+
+    private function exportRedirects(string $output, HistoryRecorder $history): void
+    {
+        $lines = [
+            '/now /now/ 301',
+        ];
+        foreach ($history->registry()->redirects() as $rule) {
+            $from = rtrim($rule['from'], '/');
+            $to = $rule['to'];
+            $lines[] = $from.' '.$to.' 301';
+            $lines[] = $from.'/ '.$to.' 301';
+        }
+
+        File::put($output.'/_redirects', implode("\n", array_unique($lines))."\n");
+    }
+
+    private function exportLegacyMap(string $output, HistoryRecorder $history): void
+    {
+        $ids = [];
+        $japanHashes = [];
+
+        foreach ($history->registry()->movies() as $key => $movie) {
+            foreach ($movie['legacyIds'] ?? [] as $legacyId) {
+                $legacyId = (string) $legacyId;
+                $ids[$legacyId] = $key;
+                $fromSlug = str_starts_with($legacyId, 'global_')
+                    ? substr($legacyId, strlen('global_'))
+                    : $legacyId;
+                $ids[$fromSlug] = $key;
+                $hash = MovieIdentity::japanHashFromLegacyId($legacyId);
+                if ($hash) {
+                    $japanHashes[$hash] = $key;
+                }
+            }
+        }
+
+        File::put($output.'/data/legacy-map.json', json_encode([
+            'ids' => $ids,
+            'japanHashes' => $japanHashes,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+    }
+
+    private function exportFeed(string $output, array $globalInsights, array $japanInsights): void
+    {
+        $baseUrl = rtrim(config('app.url'), '/');
+        $items = [];
+        foreach (array_merge($japanInsights['today'], $globalInsights['today']) as $movie) {
+            $items[] = [
+                'title' => ($movie['title'] ?? '').' '.$movie['deltaLabel'],
+                'link' => $baseUrl.'/movies/'.$movie['key'].'/',
+                'date' => $movie['lastChangeAt'] ?? $movie['lastObservedAt'] ?? now('Asia/Tokyo')->toAtomString(),
+                'body' => trim(($movie['deltaLabel'] ?? '').' / '.($movie['dailyPaceLabel'] ?? '').' / '.($movie['passedLabel'] ?? '')),
+            ];
+        }
+        foreach (array_merge($japanInsights['milestones'], $globalInsights['milestones']) as $milestone) {
+            $items[] = [
+                'title' => ($milestone['title'] ?? '').'が'.$milestone['label'],
+                'link' => $baseUrl.'/movies/'.$milestone['key'].'/',
+                'date' => $milestone['reachedAt'],
+                'body' => ($milestone['daysToReach'] !== null ? '公開'.$milestone['daysToReach'].'日目（発表ベース）' : '発表ベース'),
+            ];
+        }
+
+        usort($items, fn (array $a, array $b) => strcmp($b['date'] ?? '', $a['date'] ?? ''));
+        $items = array_slice($items, 0, 30);
+        $now = now('Asia/Tokyo')->toRfc2822String();
+
+        $entries = '';
+        foreach ($items as $item) {
+            $date = Carbon::parse($item['date'])->toRfc2822String();
+            $entries .= '    <item>'
+                .'<title>'.$this->h($item['title']).'</title>'
+                .'<link>'.$this->h($item['link']).'</link>'
+                .'<guid>'.$this->h($item['link'].'#'.$item['date']).'</guid>'
+                .'<pubDate>'.$this->h($date).'</pubDate>'
+                .'<description>'.$this->h($item['body']).'</description>'
+                ."</item>\n";
+        }
+
+        File::put($output.'/feed.xml', <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>MUBIRAN 公開中の興行収入</title>
+    <link>{$baseUrl}/now/</link>
+    <description>公開中作品の興行収入の伸びとマイルストーン</description>
+    <language>ja</language>
+    <lastBuildDate>{$now}</lastBuildDate>
+{$entries}  </channel>
+</rss>
+XML);
+    }
+
+    private function exportNowPage(string $output): void
+    {
+        File::ensureDirectoryExists($output.'/now');
+        File::put($output.'/now/index.html', $this->indexHtml('/now/'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $movie
+     */
+    private function movieMomentumHtml(array $movie): string
+    {
+        $momentum = $movie['momentum'] ?? null;
+        if (! is_array($momentum) || empty($momentum['hasHistory'])) {
+            return '';
+        }
+
+        $items = [];
+        if (! empty($momentum['deltaLabel'])) {
+            $label = $momentum['deltaLabel'];
+            if (! empty($momentum['daysSincePrev'])) {
+                $label .= '（'.$momentum['daysSincePrev'].'日前の発表比）';
+            }
+            $items[] = '<div><dt>前回からの伸び</dt><dd>'.$this->h($label).'</dd></div>';
+        }
+        if (! empty($momentum['dailyPaceLabel'])) {
+            $items[] = '<div><dt>1日あたり</dt><dd>'.$this->h($momentum['dailyPaceLabel']).'</dd></div>';
+        }
+        if (! empty($momentum['rankDeltaLabel'])) {
+            $items[] = '<div><dt>順位変動</dt><dd>'.$this->h($momentum['rankDeltaLabel']).'</dd></div>';
+        }
+        if (! empty($momentum['passedLabel'])) {
+            $items[] = '<div><dt>追い抜き</dt><dd>'.$this->h($momentum['passedLabel']).'</dd></div>';
+        }
+        if ($items === []) {
+            return '';
+        }
+
+        return '<section class="movie-section hit-scale"><h2>最近の伸び</h2><dl class="movie-stats">'.implode('', $items).'</dl><p class="hit-scale-disclaimer">発表ベースの記録です。チケット料金のインフレは未調整です。</p></section>';
     }
 
     private function exportMoviePages(string $output, $global, $japan): void
@@ -335,7 +618,7 @@ TXT);
         return '/build/' . e($this->viteEntry()['file']);
     }
 
-    private function exportSitemap(string $output, $globalModels, $japanModels): void
+    private function exportSitemap(string $output, array $global, array $japan, array $boardOnly = []): void
     {
         $baseUrl = rtrim(config('app.url'), '/');
         $defaultLastmod = now('Asia/Tokyo')->toAtomString();
@@ -345,6 +628,16 @@ TXT);
             'lastmod' => $defaultLastmod,
             'changefreq' => 'daily',
             'priority' => '1.0',
+        ], [
+            'loc' => "{$baseUrl}/now/",
+            'lastmod' => $defaultLastmod,
+            'changefreq' => 'daily',
+            'priority' => '0.8',
+        ], [
+            'loc' => "{$baseUrl}/feed.xml",
+            'lastmod' => $defaultLastmod,
+            'changefreq' => 'daily',
+            'priority' => '0.4',
         ], [
             'loc' => "{$baseUrl}/about/",
             'lastmod' => $defaultLastmod,
@@ -357,31 +650,10 @@ TXT);
             'priority' => '0.3',
         ]];
 
-        foreach ($globalModels as $movie) {
-            if (! str_starts_with($movie->movie_id, 'global_')) {
-                continue;
-            }
-
+        foreach (array_merge($global, $japan, $boardOnly) as $movie) {
             $urls[] = [
-                'loc' => "{$baseUrl}/movies/" . $this->movieSlug($movie->movie_id),
-                'lastmod' => $movie->last_updated
-                    ? Carbon::parse($movie->last_updated)->toAtomString()
-                    : $defaultLastmod,
-                'changefreq' => 'weekly',
-                'priority' => '0.6',
-            ];
-        }
-
-        foreach ($japanModels as $movie) {
-            if (! str_starts_with($movie->movie_id, 'jp_')) {
-                continue;
-            }
-
-            $urls[] = [
-                'loc' => "{$baseUrl}/movies/" . $movie->movie_id,
-                'lastmod' => $movie->last_updated
-                    ? Carbon::parse($movie->last_updated)->toAtomString()
-                    : $defaultLastmod,
+                'loc' => "{$baseUrl}/movies/" . $this->movieSlug($movie['id']) . '/',
+                'lastmod' => $defaultLastmod,
                 'changefreq' => 'weekly',
                 'priority' => '0.6',
             ];
@@ -408,7 +680,7 @@ TXT);
         $baseUrl = rtrim(config('app.url'), '/');
         $detail = $this->loadExportedDetail($output, $movie['id']) ?? [];
         $slug = $this->movieSlug($movie['id']);
-        $pageUrl = "{$baseUrl}/movies/{$slug}";
+        $pageUrl = "{$baseUrl}/movies/{$slug}/";
         $homeUrl = $baseUrl . '/?tab=' . ($isJapan ? 'japan' : 'global');
 
         $title = $movie['title'];
@@ -418,8 +690,9 @@ TXT);
         $rankLabel = $isJapan ? '日本ランキング' : '世界ランキング';
         $revenueText = $movie['revenue'] . ($movie['revenueYen'] ? "（{$movie['revenueYen']}）" : '');
 
-        $pageTitle = "{$title} の興行収入 {$movie['revenue']} | {$rankLabel}第{$movie['rank']}位 - MUBIRAN";
-        $description = "{$title}の興行収入は{$revenueText}（{$rankLabel}第{$movie['rank']}位）。";
+        $rankValue = is_numeric($movie['rank'] ?? null) ? '第'.$movie['rank'].'位' : (string) ($movie['rank'] ?? '圏外');
+        $pageTitle = "{$title} の興行収入 {$movie['revenue']} | {$rankLabel}{$rankValue} - MUBIRAN";
+        $description = "{$title}の興行収入は{$revenueText}（{$rankLabel}{$rankValue}）。";
         if ($originalTitle && $originalTitle !== $title) {
             $description .= "原題: {$originalTitle}。";
         }
@@ -516,6 +789,7 @@ TXT);
         $eOgImage = $this->h($ogImage);
         $eTitle = $this->h($title);
         $eRankLabel = $this->h($rankLabel);
+        $eRankValue = $this->h($rankValue);
         $eRevenue = $this->h($movie['revenue']);
         $eRevenueYen = $this->h($isJapan ? ($movie['revenue'] ?? '-') : ($movie['revenueYen'] ?? '-'));
         $yenRow = $isJapan ? '' : "<div><dt>日本換算</dt><dd>{$eRevenueYen}</dd></div>\n            ";
@@ -526,6 +800,7 @@ TXT);
         $eTagline = $this->h($tagline);
         $eHomeUrl = $this->h($homeUrl);
         $footerInner = $this->siteFooterInnerHtml();
+        $momentumHtml = $this->movieMomentumHtml($movie);
 
         return <<<HTML
 <!doctype html>
@@ -579,7 +854,7 @@ TXT);
         <div class="movie-hero">
           {$posterHtml}
           <dl class="movie-stats">
-            <div><dt>{$eRankLabel}</dt><dd>第{$movie['rank']}位</dd></div>
+            <div><dt>{$eRankLabel}</dt><dd>{$eRankValue}</dd></div>
             <div><dt>興行収入</dt><dd>{$eRevenue}</dd></div>
             {$yenRow}
             <div><dt>公開日</dt><dd>{$eReleaseDate}</dd></div>
@@ -590,6 +865,7 @@ TXT);
         </div>
         <p class="movie-tagline">{$eTagline}</p>
         {$genreHtml}
+        {$momentumHtml}
         <section class="movie-section">
           <h2>あらすじ</h2>
           {$overviewHtml}
@@ -623,7 +899,7 @@ HTML;
         $year = $this->h((string) now('Asia/Tokyo')->year);
 
         return <<<HTML
-        <p class="site-footer-links"><a href="/about/">このサイトについて</a> · <a href="/privacy/">プライバシーポリシー</a></p>
+        <p class="site-footer-links"><a href="/now/">公開中の動向</a> · <a href="/about/">このサイトについて</a> · <a href="/privacy/">プライバシーポリシー</a> · <a href="/feed.xml">RSS</a></p>
         <p>&copy; {$year} MUBIRAN. All rights reserved.</p>
         <p>Data provided by <a href="https://www.themoviedb.org/" target="_blank" rel="noreferrer">TMDb</a> and <a href="https://ja.wikipedia.org/" target="_blank" rel="noreferrer">Wikipedia</a>.</p>
 HTML;
@@ -715,7 +991,11 @@ HTML;
         $body = <<<'HTML'
         <section class="content-section">
           <h2>MUBIRAN（ムビラン）とは</h2>
-          <p>MUBIRANは、世界と日本の映画興行収入ランキングをわかりやすく掲載する情報サイトです。歴代ヒット作の興行成績を比較し、作品ごとの詳細情報も確認できます。</p>
+          <p>MUBIRANは、世界と日本の映画興行収入ランキングをわかりやすく掲載する情報サイトです。歴代ヒット作の興行成績に加え、公開中作品の伸びや順位変動も追えます。</p>
+        </section>
+        <section class="content-section">
+          <h2>公開中の動向について</h2>
+          <p>日本の興行収入は配給会社の発表ベースで更新されるため、毎日数字が動くわけではありません。当サイトは発表のたびに記録し、前回発表からの伸び・1日あたりのペース・順位変動を表示します。チケット料金のインフレは未調整です。</p>
         </section>
         <section class="content-section">
           <h2>掲載データについて</h2>
@@ -777,7 +1057,7 @@ HTML;
         </section>
         <section class="content-section">
           <h2>Cookie・ローカルストレージ</h2>
-          <p>当サイトでは、表示の利便性向上のため Service Worker を利用することがあります。ブラウザに保存されるデータは、サイトの高速表示やオフライン対応を目的としたものであり、広告配信や第三者への販売には使用しません。</p>
+          <p>当サイトでは、表示の利便性向上のため Service Worker を利用することがあります。公開中ボードでは、前回訪問時からの興収差を表示するためにブラウザのローカルストレージを使います。これらのデータは端末内にのみ保存され、広告配信や第三者への販売には使用しません。</p>
         </section>
         <section class="content-section">
           <h2>第三者サービス</h2>
@@ -814,6 +1094,30 @@ HTML;
         $body = <<<'HTML'
         <p class="content-lead">お探しのページは見つかりませんでした。URLが変更されたか、削除された可能性があります。</p>
         <p class="content-back-link"><a href="/">ランキングトップへ戻る</a></p>
+        <script>
+        (function () {
+          var path = location.pathname.replace(/\/+$/, '');
+          var prefix = '/movies/';
+          if (path.indexOf(prefix) !== 0) return;
+          var slug = decodeURIComponent(path.slice(prefix.length));
+          if (!slug || slug.indexOf('/') !== -1) return;
+          var global = slug.match(/^(\d{3})_(\d+)$/);
+          if (global) {
+            location.replace('/movies/tmdb-' + global[2] + '/');
+            return;
+          }
+          var japan = slug.match(/^jp_\d{3}_([0-9a-f]{8})$/);
+          fetch('/data/legacy-map.json').then(function (response) {
+            return response.ok ? response.json() : null;
+          }).then(function (map) {
+            if (!map) return;
+            var key = (map.ids && map.ids[slug]) || (japan && map.japanHashes && map.japanHashes[japan[1]]);
+            if (key && key !== slug) {
+              location.replace('/movies/' + encodeURIComponent(key) + '/');
+            }
+          }).catch(function () {});
+        })();
+        </script>
 HTML;
 
         return $this->contentPageHtml(
@@ -827,15 +1131,21 @@ HTML;
         );
     }
 
-    private function indexHtml(): string
+    private function indexHtml(string $path = '/'): string
     {
         $styles = $this->viteStyles();
         $script = $this->viteScript();
 
         $baseUrl = rtrim(config('app.url'), '/');
-        $title = '歴代映画興行収入ランキング | 世界・日本のヒット作を徹底分析 - MUBIRAN';
-        $description = '「アバター」「鬼滅の刃」など、世界と日本の歴代ヒット映画の興行収入ランキングを完全網羅。興収だけでなく制作費や利益率まで可視化。あなたの好きな映画は今何位？最新データを毎日更新。';
-        $keywords = '映画,興行収入,ランキング,売上,日本映画,世界の映画,最新,ムビラン,ボックスオフィス,映画統計,映画データ,映画売上,興行成績,映画ランキング,最新映画';
+        $canonical = $baseUrl.($path === '/' ? '/' : rtrim($path, '/').'/');
+        $isNow = $path === '/now/';
+        $title = $isNow
+            ? '公開中の興行収入動向 | MUBIRAN'
+            : '歴代映画興行収入ランキング | 世界・日本のヒット作を徹底分析 - MUBIRAN';
+        $description = $isNow
+            ? '公開中の映画がどれくらいのペースで興行収入を伸ばしているかを追跡。前回発表からの伸び、1日あたりのペース、順位変動を毎日確認できます。'
+            : '「アバター」「鬼滅の刃」など、世界と日本の歴代ヒット映画の興行収入ランキングを完全網羅。興収だけでなく制作費や利益率まで可視化。あなたの好きな映画は今何位？最新データを毎日更新。';
+        $keywords = '映画,興行収入,ランキング,売上,日本映画,世界の映画,最新,ムビラン,ボックスオフィス,映画統計,映画データ,映画売上,興行成績,映画ランキング,最新映画,公開中';
         $ogImage = $baseUrl . '/images/android-chrome-512x512.png';
 
         return <<<HTML
@@ -849,7 +1159,7 @@ HTML;
     <meta name="robots" content="index, follow">
     <meta name="author" content="ムビラン">
     <meta name="language" content="ja">
-    <link rel="canonical" href="{$baseUrl}/">
+    <link rel="canonical" href="{$canonical}">
     <title>{$title}</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
@@ -860,7 +1170,7 @@ HTML;
     <meta property="og:title" content="{$title}">
     <meta property="og:description" content="{$description}">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{$baseUrl}/">
+    <meta property="og:url" content="{$canonical}">
     <meta property="og:image" content="{$ogImage}">
     <meta property="og:locale" content="ja_JP">
     <meta property="og:site_name" content="MUBIRAN - 映画興行収入ランキング">

--- a/app/Console/Commands/FetchGlobalBoxOffice.php
+++ b/app/Console/Commands/FetchGlobalBoxOffice.php
@@ -2,18 +2,22 @@
 
 namespace App\Console\Commands;
 
+use App\Console\Traits\SavesMovieImages;
+use App\Mail\BoxOfficeFetchError;
+use App\Models\GlobalMovie;
+use App\Services\BoxOffice\HistoryRecorder;
+use App\Services\BoxOffice\MovieIdentity;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use App\Models\GlobalMovie;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
-use App\Mail\BoxOfficeFetchError;
-use App\Console\Traits\SavesMovieImages;
 
 class FetchGlobalBoxOffice extends Command
 {
     use SavesMovieImages;
+
+    private HistoryRecorder $history;
 
     protected $signature = 'movies:fetch-global-boxoffice';
     protected $description = '世界の映画興行収入データを取得・更新します（日本を除く）';
@@ -23,6 +27,7 @@ class FetchGlobalBoxOffice extends Command
         try {
             $api_key = config('services.tmdb.api_key');
             $this->info('TMDb APIを使用してデータ取得を開始...');
+            $this->history = HistoryRecorder::fromBasePath(base_path('data/history'));
 
             // 既存のAI分析データを事前に退避（DB接続タイムアウト回避のため早期に取得）
             $existingAnalyses = GlobalMovie::where('region', 'global')
@@ -110,6 +115,24 @@ class FetchGlobalBoxOffice extends Command
 
                             $totalMovies++;
                             $rank = $totalMovies;
+                            $tmdbId = (int) $movie['id'];
+                            $key = MovieIdentity::globalKey($tmdbId);
+                            $releaseDate = ! empty($movie['release_date']) ? $movie['release_date'] : null;
+                            $year = $releaseDate ? (int) substr($releaseDate, 0, 4) : null;
+
+                            $this->history->resolve([
+                                'region' => 'global',
+                                'title' => $movieDetails['title'] ?? $movie['title'],
+                                'tmdbId' => $tmdbId,
+                                'releaseYear' => $year,
+                                'releaseDate' => $releaseDate,
+                                'releaseDatePrecision' => $releaseDate ? 'day' : null,
+                                'legacyIds' => [
+                                    MovieIdentity::globalLegacyId($rank, $tmdbId),
+                                    MovieIdentity::globalLegacySlug($rank, $tmdbId),
+                                ],
+                                'now' => now('Asia/Tokyo')->toIso8601String(),
+                            ]);
 
                             // genresをJSON文字列に変換
                             $genres = isset($movieDetails['genres']) 
@@ -119,24 +142,28 @@ class FetchGlobalBoxOffice extends Command
                             // ポスター画像の保存処理
                             $localPosterPath = null;
                             if (!empty($movieDetails['poster_path'])) {
-                                $filenameBase = 'global_' . sprintf('%03d', $rank) . '_' . $movie['id'];
-                                $localPosterPath = $this->downloadAndSaveImage($movieDetails['poster_path'], $filenameBase);
+                                $localPosterPath = $this->downloadAndSaveImage($movieDetails['poster_path'], $key);
                                 if ($localPosterPath) {
                                     $this->info("ポスター画像を保存しました: {$localPosterPath}");
                                 }
                             }
 
+                            $isActive = $releaseDate
+                                && $releaseDate >= now('Asia/Tokyo')->subMonths(6)->toDateString();
+
                             $movies[] = [
-                                'movie_id' => 'global_' . sprintf('%03d', $rank) . '_' . $movie['id'],
-                                'tmdb_id' => $movie['id'],
+                                'movie_id' => $key,
+                                'tmdb_id' => $tmdbId,
                                 'title' => $movieDetails['title'] ?? $movie['title'],
                                 'original_title' => $englishDetails['title'] ?? ($movieDetails['original_title'] ?? null),
                                 'poster_path' => $localPosterPath,
                                 'box_office' => $movieDetails['revenue'] ?? 0,
                                 'budget' => $movieDetails['budget'] ?? 0,
-                                'release_date' => !empty($movie['release_date']) ? $movie['release_date'] : null,
+                                'release_date' => $releaseDate,
+                                'release_date_precision' => $releaseDate ? 'day' : null,
                                 'rank' => $rank,
                                 'region' => 'global',
+                                'is_active' => $isActive ? 1 : 0,
                                 'genres' => $genres,  // JSON文字列として保存
                                 'production_country' => isset($movieDetails['production_countries'][0]) 
                                     ? $movieDetails['production_countries'][0]['iso_3166_1'] 
@@ -184,7 +211,20 @@ class FetchGlobalBoxOffice extends Command
 
             // データベースへの一括登録
             if (!empty($movies)) {
+                if (count($movies) < HistoryRecorder::MINIMUM_MOVIES) {
+                    $this->error(sprintf(
+                        '取得件数が%d件で下限%d件を下回ったため、履歴もデータベースも更新しません',
+                        count($movies),
+                        HistoryRecorder::MINIMUM_MOVIES
+                    ));
+                    return self::FAILURE;
+                }
+
                 $this->info('データベースへの一括登録を開始...');
+
+                foreach ($this->history->recordSnapshot('global', $movies, now('Asia/Tokyo')) as $warning) {
+                    $this->warn($warning);
+                }
                 
                 // 既存のトランザクションがあれば終了
                 try {

--- a/app/Console/Commands/FetchJapaneseBoxOffice.php
+++ b/app/Console/Commands/FetchJapaneseBoxOffice.php
@@ -2,20 +2,24 @@
 
 namespace App\Console\Commands;
 
+use App\Mail\BoxOfficeFetchError;
 use App\Models\JapaneseMovie;
+use App\Services\BoxOffice\HistoryRecorder;
+use App\Services\BoxOffice\MovieIdentity;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\DB;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
-use App\Mail\BoxOfficeFetchError;
+use Illuminate\Support\Str;
 use App\Console\Traits\SavesMovieImages;
 
 class FetchJapaneseBoxOffice extends Command
 {
     use SavesMovieImages;
+
+    private HistoryRecorder $history;
 
     /**
      * The name and signature of the console command.
@@ -45,6 +49,7 @@ class FetchJapaneseBoxOffice extends Command
             Log::withoutContext();
             
             $this->info('Wikipediaからデータ取得を開始...');
+            $this->history = HistoryRecorder::fromBasePath(base_path('data/history'));
             
             // 既存のAI分析データを事前に退避（DB接続タイムアウト回避のため早期に取得）
             $existingAnalyses = JapaneseMovie::whereNotNull('ai_analysis')
@@ -104,6 +109,19 @@ class FetchJapaneseBoxOffice extends Command
                         }
                     }
                     unset($m);
+
+                    if (count($moviesData) < HistoryRecorder::MINIMUM_MOVIES) {
+                        $this->error(sprintf(
+                            '取得件数が%d件で下限%d件を下回ったため、履歴もデータベースも更新しません',
+                            count($moviesData),
+                            HistoryRecorder::MINIMUM_MOVIES
+                        ));
+                        return self::FAILURE;
+                    }
+
+                    foreach ($this->history->recordSnapshot('japan', $moviesData, now('Asia/Tokyo')) as $warning) {
+                        $this->warn($warning);
+                    }
 
                     // 既存のトランザクションがあれば終了
                     try {
@@ -196,6 +214,7 @@ class FetchJapaneseBoxOffice extends Command
             $this->info('Wikiテキストの解析を開始...');
             
             $movies = [];
+            $seenKeys = [];
             $currentRank = null;
             $rankBoxOfficeMap = []; // 順位ごとの興行収入を保存
 
@@ -343,7 +362,11 @@ class FetchJapaneseBoxOffice extends Command
 
                         // TMDBからジャンルと制作費をまとめて取得（APIリクエスト削減）
                         $tmdbDetails = $this->fetchTMDBDetails($title, $wikidataReleaseDate);
-                        
+                        $releasePrecision = $tmdbDetails['release_date_precision'] ?? 'year';
+                        if (!empty($tmdbDetails['release_date']) && $releasePrecision === 'day') {
+                            $wikidataReleaseDate = $this->sanitizeReleaseDate($tmdbDetails['release_date'], $wikidataReleaseDate);
+                        }
+
                         $tmdbGenres = $tmdbDetails['genres'];
                         $tmdbBudgetYen = $tmdbDetails['budget'];
 
@@ -362,17 +385,46 @@ class FetchJapaneseBoxOffice extends Command
 
                         $genresToSave = !empty($tmdbGenres) ? $tmdbGenres : $wikidataGenres;
                         
+                        $year = $wikidataReleaseDate ? (int) substr($wikidataReleaseDate, 0, 4) : null;
+                        $resolved = $this->history->resolve([
+                            'region' => 'japan',
+                            'title' => $title,
+                            'tmdbId' => $tmdbDetails['tmdb_id'] ?? null,
+                            'releaseYear' => $year,
+                            'releaseDate' => $wikidataReleaseDate,
+                            'releaseDatePrecision' => $releasePrecision,
+                            'legacyIds' => [
+                                MovieIdentity::japanLegacyId(
+                                    (int) $currentRank,
+                                    $title,
+                                    $distributor,
+                                    $releaseYear ?? ''
+                                ),
+                            ],
+                            'now' => now('Asia/Tokyo')->toIso8601String(),
+                        ]);
+
+                        if (isset($seenKeys[$resolved['key']])) {
+                            $this->warn(sprintf(
+                                '安定キーが重複したためスキップ: %s（%s / 順位%d）',
+                                $resolved['key'],
+                                $title,
+                                $currentRank
+                            ));
+                            continue;
+                        }
+                        $seenKeys[$resolved['key']] = true;
+
                         $localPosterPath = null;
                         if (!empty($tmdbDetails['poster_path'])) {
-                             $filenameBase = 'jp_' . sprintf('%03d', $currentRank) . '_' . ($tmdbDetails['tmdb_id'] ?? 'unknown');
-                             $localPosterPath = $this->downloadAndSaveImage($tmdbDetails['poster_path'], $filenameBase);
+                             $localPosterPath = $this->downloadAndSaveImage($tmdbDetails['poster_path'], $resolved['key']);
                              if ($localPosterPath) {
                                  $this->info("ポスター画像を保存しました: {$localPosterPath}");
                              }
                         }
 
                         $movieData = [
-                            'movie_id' => $this->createMovieId($currentRank, $title, $distributor, $wikidataReleaseDate),
+                            'movie_id' => $resolved['key'],
                             'tmdb_id' => $tmdbDetails['tmdb_id'] ?? null,
                             'title' => $title,
                             'original_title' => $tmdbDetails['original_title'] ?? null,
@@ -382,6 +434,7 @@ class FetchJapaneseBoxOffice extends Command
                             'production_country' => $productionCountry,
                             'distributor' => $distributor,
                             'release_date' => $wikidataReleaseDate,
+                            'release_date_precision' => $releasePrecision,
                             'last_updated' => now(),
                             'genres' => json_encode($genresToSave),
                             'budget' => $budgetToSave,
@@ -692,7 +745,15 @@ class FetchJapaneseBoxOffice extends Command
     // TMDBから作品詳細（ジャンル、制作費）を一括取得
     private function fetchTMDBDetails(string $title, ?string $releaseDate = null): array
     {
-        $defaultResult = ['genres' => [], 'budget' => 0, 'original_title' => null, 'tmdb_id' => null, 'poster_path' => null];
+        $defaultResult = [
+            'genres' => [],
+            'budget' => 0,
+            'original_title' => null,
+            'tmdb_id' => null,
+            'poster_path' => null,
+            'release_date' => null,
+            'release_date_precision' => 'year',
+        ];
         $apiKey = config('services.tmdb.api_key');
         if (empty($apiKey)) {
             return $defaultResult;
@@ -767,7 +828,8 @@ class FetchJapaneseBoxOffice extends Command
             // 2. 詳細取得
             $detailsResponse = Http::get("https://api.themoviedb.org/3/movie/{$bestMatch['id']}", [
                 'api_key' => $apiKey,
-                'language' => 'ja-JP'
+                'language' => 'ja-JP',
+                'append_to_response' => 'release_dates',
             ]);
             usleep(100000);
 
@@ -787,18 +849,52 @@ class FetchJapaneseBoxOffice extends Command
                 $budgetYen = (int) round($budgetUsd * 150);
             }
 
+            $japanReleaseDate = $this->extractJapanTheatricalDate($details);
+            $tmdbReleaseDate = $this->sanitizeReleaseDate($details['release_date'] ?? null);
+            $releaseDate = $japanReleaseDate ?: $tmdbReleaseDate;
+            $releasePrecision = $releaseDate && ! str_ends_with($releaseDate, '-01-01') ? 'day' : 'year';
+            if ($japanReleaseDate) {
+                $releasePrecision = 'day';
+            }
+
             return [
                 'genres' => $genres,
                 'budget' => $budgetYen,
                 'original_title' => $details['original_title'] ?? null,
                 'tmdb_id' => $details['id'],
-                'poster_path' => $details['poster_path']
+                'poster_path' => $details['poster_path'],
+                'release_date' => $releaseDate,
+                'release_date_precision' => $releasePrecision,
             ];
 
         } catch (\Exception $e) {
             $this->warn('TMDB詳細取得に失敗: ' . $e->getMessage());
             return $defaultResult;
         }
+    }
+
+    private function extractJapanTheatricalDate(array $details): ?string
+    {
+        $results = $details['release_dates']['results'] ?? [];
+        $fallback = null;
+
+        foreach ($results as $country) {
+            if (($country['iso_3166_1'] ?? '') !== 'JP') {
+                continue;
+            }
+            foreach ($country['release_dates'] ?? [] as $release) {
+                $date = isset($release['release_date']) ? substr((string) $release['release_date'], 0, 10) : null;
+                if (! $date) {
+                    continue;
+                }
+                if ((int) ($release['type'] ?? 0) === 3) {
+                    return $this->sanitizeReleaseDate($date);
+                }
+                $fallback ??= $date;
+            }
+        }
+
+        return $this->sanitizeReleaseDate($fallback);
     }
 
     private function createMovieData($movie, $tmdbDetails, $now)

--- a/app/Console/Traits/FetchesTmdbMovieDetails.php
+++ b/app/Console/Traits/FetchesTmdbMovieDetails.php
@@ -4,6 +4,7 @@ namespace App\Console\Traits;
 
 use App\Models\GlobalMovie;
 use App\Models\JapaneseMovie;
+use App\Services\BoxOffice\MovieIdentity;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 
@@ -33,6 +34,11 @@ trait FetchesTmdbMovieDetails
     {
         if (! empty($movie->tmdb_id)) {
             return (int) $movie->tmdb_id;
+        }
+
+        $fromKey = MovieIdentity::tmdbIdFromKey((string) $movie->movie_id);
+        if ($fromKey) {
+            return $fromKey;
         }
 
         if (str_starts_with($movie->movie_id, 'global_')) {

--- a/app/Models/GlobalMovie.php
+++ b/app/Models/GlobalMovie.php
@@ -26,11 +26,13 @@ class GlobalMovie extends Model
         'box_office',
         'budget',
         'release_date',
+        'release_date_precision',
         'region',
         'genres',
         'data_source',
         'data_source_url',
-        'last_updated'
+        'last_updated',
+        'is_active'
     ];
 
     protected $casts = [
@@ -38,7 +40,8 @@ class GlobalMovie extends Model
         'release_date' => 'date',
         'box_office' => 'integer',
         'budget' => 'integer',
-        'last_updated' => 'datetime'
+        'last_updated' => 'datetime',
+        'is_active' => 'boolean',
     ];
 
     protected $attributes = [

--- a/app/Models/JapaneseMovie.php
+++ b/app/Models/JapaneseMovie.php
@@ -25,6 +25,7 @@ class JapaneseMovie extends Model
         'box_office',
         'budget',
         'release_date',
+        'release_date_precision',
         'genres',
         'production_country',
         'distributor',

--- a/app/Services/BoxOffice/HistoryRecorder.php
+++ b/app/Services/BoxOffice/HistoryRecorder.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Services\BoxOffice;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+
+class HistoryRecorder
+{
+    public const MINIMUM_MOVIES = 150;
+
+    public function __construct(
+        private readonly Registry $registry,
+        private readonly ObservationStore $observations,
+    ) {
+    }
+
+    public static function fromBasePath(string $historyDir): self
+    {
+        return new self(
+            new Registry(rtrim($historyDir, '/').'/registry.json'),
+            new ObservationStore(rtrim($historyDir, '/').'/observations'),
+        );
+    }
+
+    public function registry(): Registry
+    {
+        return $this->registry;
+    }
+
+    public function observations(): ObservationStore
+    {
+        return $this->observations;
+    }
+
+    /**
+     * @param  array<string, mixed>  $incoming
+     * @return array<string, mixed>
+     */
+    public function resolve(array $incoming): array
+    {
+        return $this->registry->resolve($incoming);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $movies
+     * @return list<string>
+     */
+    public function recordSnapshot(string $region, array $movies, DateTimeInterface $observedAt): array
+    {
+        $iso = DateTimeImmutable::createFromInterface($observedAt)->format('c');
+        $existing = $this->observations->loadByKey($region);
+        $currentKeys = [];
+        $warnings = [];
+
+        foreach ($movies as $movie) {
+            $key = (string) $movie['movie_id'];
+            $currentKeys[$key] = true;
+            $row = [
+                'key' => $key,
+                'observedAt' => $iso,
+                'boxOffice' => (int) $movie['box_office'],
+                'isActive' => (bool) ($movie['is_active'] ?? false),
+            ];
+            if ((int) $movie['box_office'] < (int) ($this->observations->lastForKey($existing[$key] ?? [])['boxOffice'] ?? 0)) {
+                $row['correction'] = true;
+            }
+            $previous = $this->observations->lastForKey($existing[$key] ?? []);
+            if ($this->observations->shouldRecord($row, $previous)) {
+                $this->observations->append($region, $row);
+                $existing[$key][] = $row;
+            }
+        }
+
+        foreach ($existing as $key => $rows) {
+            $last = $this->observations->lastForKey($rows);
+            if ($last && ! empty($last['isActive']) && ! isset($currentKeys[$key])) {
+                $title = $this->registry->get($key)['title'] ?? $key;
+                $warnings[] = "公開中だった『{$title}』({$key}) が今回の取得結果から消えました。";
+                $closing = [
+                    'key' => $key,
+                    'observedAt' => $iso,
+                    'boxOffice' => (int) ($last['boxOffice'] ?? 0),
+                    'isActive' => false,
+                ];
+                if ($this->observations->shouldRecord($closing, $last)) {
+                    $this->observations->append($region, $closing);
+                    $existing[$key][] = $closing;
+                }
+            }
+        }
+
+        $this->registry->save();
+
+        return $warnings;
+    }
+
+    public function save(): void
+    {
+        $this->registry->save();
+    }
+}

--- a/app/Services/BoxOffice/Insights.php
+++ b/app/Services/BoxOffice/Insights.php
@@ -1,0 +1,535 @@
+<?php
+
+namespace App\Services\BoxOffice;
+
+use DateInterval;
+use DateTimeImmutable;
+
+class Insights
+{
+    public const BOARD_MOVED_WITHIN_DAYS = 30;
+
+    public const TODAY_WITHIN_HOURS = 72;
+
+    /** @var list<int> */
+    public const JAPAN_MILESTONES = [
+        1_000_000_000,
+        3_000_000_000,
+        5_000_000_000,
+        10_000_000_000,
+        15_000_000_000,
+        20_000_000_000,
+        30_000_000_000,
+        40_000_000_000,
+    ];
+
+    /** @var list<int> */
+    public const GLOBAL_MILESTONES = [
+        100_000_000,
+        500_000_000,
+        1_000_000_000,
+        2_000_000_000,
+    ];
+
+    /**
+     * @param  list<array<string, mixed>>  $currentMovies
+     * @param  array<string, list<array<string, mixed>>>  $observationsByKey
+     * @param  array<string, array<string, mixed>>  $registryMovies
+     * @return array{
+     *     movies: array<string, array<string, mixed>>,
+     *     board: list<array<string, mixed>>,
+     *     today: list<array<string, mixed>>,
+     *     milestones: list<array<string, mixed>>
+     * }
+     */
+    public static function compute(
+        string $region,
+        array $currentMovies,
+        array $observationsByKey,
+        array $registryMovies,
+        DateTimeImmutable $now,
+    ): array {
+        $currentByKey = [];
+        foreach ($currentMovies as $movie) {
+            $currentByKey[$movie['key']] = $movie;
+        }
+
+        $rankedNow = self::ranksFromSnapshot(array_map(
+            fn (array $movie) => ['key' => $movie['key'], 'boxOffice' => (int) $movie['boxOffice']],
+            $currentMovies,
+        ));
+
+        $weekAgo = $now->sub(new DateInterval('P7D'));
+        $rankedThen = self::ranksFromSnapshot(self::snapshotAt($currentByKey, $observationsByKey, $weekAgo));
+
+        $movies = [];
+        $board = [];
+        $today = [];
+        $milestones = [];
+
+        foreach ($currentMovies as $movie) {
+            self::collectInsight(
+                $region,
+                $movie,
+                $observationsByKey[$movie['key']] ?? [],
+                $registryMovies[$movie['key']] ?? [],
+                $rankedNow[$movie['key']] ?? null,
+                $rankedThen[$movie['key']] ?? null,
+                $currentByKey,
+                $now,
+                $movies,
+                $board,
+                $today,
+                $milestones,
+            );
+        }
+
+        foreach ($observationsByKey as $key => $rows) {
+            if (isset($movies[$key])) {
+                continue;
+            }
+            $last = $rows === [] ? null : $rows[array_key_last($rows)];
+            if ($last === null) {
+                continue;
+            }
+            $registry = $registryMovies[$key] ?? [];
+            self::collectInsight(
+                $region,
+                [
+                    'key' => $key,
+                    'title' => $registry['title'] ?? $key,
+                    'boxOffice' => (int) ($last['boxOffice'] ?? 0),
+                    'isActive' => (bool) ($last['isActive'] ?? false),
+                    'releaseDate' => $registry['releaseDate'] ?? null,
+                    'releaseDatePrecision' => $registry['releaseDatePrecision'] ?? null,
+                ],
+                $rows,
+                $registry,
+                null,
+                $rankedThen[$key] ?? null,
+                $currentByKey,
+                $now,
+                $movies,
+                $board,
+                $today,
+                $milestones,
+            );
+        }
+
+        usort($board, function (array $a, array $b) {
+            $deltaA = $a['delta'] ?? -1;
+            $deltaB = $b['delta'] ?? -1;
+            if ($deltaA === $deltaB) {
+                return $b['boxOffice'] <=> $a['boxOffice'];
+            }
+
+            return $deltaB <=> $deltaA;
+        });
+
+        usort($today, fn (array $a, array $b) => strcmp($b['lastObservedAt'] ?? '', $a['lastObservedAt'] ?? ''));
+        usort($milestones, fn (array $a, array $b) => strcmp($b['reachedAt'] ?? '', $a['reachedAt'] ?? ''));
+
+        return [
+            'movies' => $movies,
+            'board' => $board,
+            'today' => array_slice($today, 0, 20),
+            'milestones' => array_slice($milestones, 0, 10),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $movie
+     * @param  list<array<string, mixed>>  $observations
+     * @param  array<string, mixed>  $registry
+     * @param  array<string, array<string, mixed>>  $currentByKey
+     * @param  array<string, array<string, mixed>>  $movies
+     * @param  list<array<string, mixed>>  $board
+     * @param  list<array<string, mixed>>  $today
+     * @param  list<array<string, mixed>>  $milestones
+     */
+    private static function collectInsight(
+        string $region,
+        array $movie,
+        array $observations,
+        array $registry,
+        ?int $rankNow,
+        ?int $rankThen,
+        array $currentByKey,
+        DateTimeImmutable $now,
+        array &$movies,
+        array &$board,
+        array &$today,
+        array &$milestones,
+    ): void {
+        $insight = self::forMovie(
+            $region,
+            $movie,
+            $observations,
+            $registry,
+            $rankNow,
+            $rankThen,
+            $currentByKey,
+            $now,
+        );
+        $movies[$movie['key']] = $insight;
+
+        if ($insight['onBoard']) {
+            $board[] = $insight;
+        }
+        if ($insight['changedRecently']) {
+            $today[] = $insight;
+        }
+        foreach ($insight['recentMilestones'] as $milestone) {
+            $milestones[] = $milestone;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $movie
+     * @param  list<array<string, mixed>>  $observations
+     * @param  array<string, mixed>  $registry
+     * @param  array<string, array<string, mixed>>  $currentByKey
+     * @return array<string, mixed>
+     */
+    public static function forMovie(
+        string $region,
+        array $movie,
+        array $observations,
+        array $registry,
+        ?int $rankNow,
+        ?int $rankThen,
+        array $currentByKey,
+        DateTimeImmutable $now,
+    ): array {
+        $boxOffice = (int) $movie['boxOffice'];
+        $isJapan = $region === 'japan';
+        $growth = self::growth($observations);
+        $last = $observations === [] ? null : $observations[array_key_last($observations)];
+        $lastObservedAt = $last['observedAt'] ?? null;
+        $precision = $registry['releaseDatePrecision'] ?? ($movie['releaseDatePrecision'] ?? null);
+        $releaseDate = $registry['releaseDate'] ?? ($movie['releaseDate'] ?? null);
+        $daysSinceRelease = self::daysSinceRelease($releaseDate, $precision, $now);
+        $lastChangeAt = self::lastChangeAt($observations);
+        $movedRecently = $lastChangeAt !== null
+            && self::hoursBetween(new DateTimeImmutable($lastChangeAt), $now) <= (self::BOARD_MOVED_WITHIN_DAYS * 24);
+        $isActive = (bool) ($movie['isActive'] ?? false);
+        $onBoard = $isActive || $movedRecently;
+        $changedRecently = $lastChangeAt !== null
+            && self::hoursBetween(new DateTimeImmutable($lastChangeAt), $now) <= self::TODAY_WITHIN_HOURS
+            && count($observations) > 1;
+
+        $milestones = self::milestones($region, $movie, $observations, $releaseDate, $precision);
+        $recentMilestones = array_values(array_filter(
+            $milestones,
+            fn (array $item) => isset($item['reachedAt'])
+                && self::hoursBetween(new DateTimeImmutable($item['reachedAt']), $now) <= (self::BOARD_MOVED_WITHIN_DAYS * 24),
+        ));
+
+        $passed = [];
+        if (($growth['previousBoxOffice'] ?? null) !== null && ($growth['delta'] ?? 0) > 0) {
+            $passed = self::passedMovies($movie['key'], (int) $growth['previousBoxOffice'], $boxOffice, $currentByKey);
+        }
+
+        $rankDelta = ($rankNow !== null && $rankThen !== null) ? $rankThen - $rankNow : null;
+
+        return [
+            'key' => $movie['key'],
+            'title' => $movie['title'],
+            'region' => $region,
+            'boxOffice' => $boxOffice,
+            'revenueLabel' => self::formatAmount($boxOffice, $isJapan),
+            'isActive' => $isActive,
+            'rank' => $rankNow ?? ($movie['rank'] ?? null),
+            'rankBefore' => $rankThen,
+            'rankDelta' => $rankDelta,
+            'rankDeltaLabel' => self::rankDeltaLabel($rankDelta),
+            'delta' => $growth['delta'],
+            'deltaLabel' => $growth['delta'] === null ? null : self::formatDelta($growth['delta'], $isJapan),
+            'daysSincePrev' => $growth['days'],
+            'previousObservedAt' => $growth['previousObservedAt'],
+            'dailyPace' => $growth['dailyPace'],
+            'dailyPaceLabel' => $growth['dailyPace'] === null ? null : '1日'.self::formatAmount((int) round($growth['dailyPace']), $isJapan),
+            'lastObservedAt' => $lastObservedAt,
+            'lastChangeAt' => $lastChangeAt,
+            'daysSinceRelease' => $daysSinceRelease,
+            'releaseDate' => $releaseDate,
+            'releaseDatePrecision' => $precision,
+            'onBoard' => $onBoard,
+            'changedRecently' => $changedRecently,
+            'passed' => $passed,
+            'passedLabel' => $passed === [] ? null : self::passedLabel($passed),
+            'milestones' => $milestones,
+            'recentMilestones' => $recentMilestones,
+            'sparkline' => self::sparkline($observations),
+            'hasHistory' => count($observations) > 1,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $observations
+     * @return array{delta: int|null, days: int|null, dailyPace: float|null, previousBoxOffice: int|null, previousObservedAt: string|null}
+     */
+    public static function growth(array $observations): array
+    {
+        $empty = [
+            'delta' => null,
+            'days' => null,
+            'dailyPace' => null,
+            'previousBoxOffice' => null,
+            'previousObservedAt' => null,
+        ];
+        if (count($observations) < 2) {
+            return $empty;
+        }
+
+        $current = $observations[array_key_last($observations)];
+        $previous = null;
+        for ($i = count($observations) - 2; $i >= 0; $i--) {
+            if (! empty($observations[$i]['correction'])) {
+                continue;
+            }
+            $previous = $observations[$i];
+            break;
+        }
+
+        if ($previous === null || ! empty($current['correction'])) {
+            return $empty;
+        }
+
+        $delta = (int) $current['boxOffice'] - (int) $previous['boxOffice'];
+        if ($delta <= 0) {
+            return $empty;
+        }
+
+        $days = max(1, (int) floor(self::hoursBetween(
+            new DateTimeImmutable($previous['observedAt']),
+            new DateTimeImmutable($current['observedAt']),
+        ) / 24));
+
+        return [
+            'delta' => $delta,
+            'days' => $days,
+            'dailyPace' => $delta / $days,
+            'previousBoxOffice' => (int) $previous['boxOffice'],
+            'previousObservedAt' => $previous['observedAt'],
+        ];
+    }
+
+    /**
+     * @param  list<array{key: string, boxOffice: int}>  $snapshot
+     * @return array<string, int>
+     */
+    public static function ranksFromSnapshot(array $snapshot): array
+    {
+        usort($snapshot, fn (array $a, array $b) => $b['boxOffice'] <=> $a['boxOffice']);
+        $ranks = [];
+        $rank = 1;
+        foreach ($snapshot as $row) {
+            $ranks[$row['key']] = $rank++;
+        }
+
+        return $ranks;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $currentByKey
+     * @param  array<string, list<array<string, mixed>>>  $observationsByKey
+     * @return list<array{key: string, boxOffice: int}>
+     */
+    public static function snapshotAt(array $currentByKey, array $observationsByKey, DateTimeImmutable $at): array
+    {
+        $snapshot = [];
+        foreach ($currentByKey as $key => $movie) {
+            $value = self::boxOfficeAt($observationsByKey[$key] ?? [], $at);
+            if ($value === null) {
+                continue;
+            }
+            $snapshot[] = ['key' => $key, 'boxOffice' => $value];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $observations
+     */
+    public static function boxOfficeAt(array $observations, DateTimeImmutable $at): ?int
+    {
+        $latest = null;
+        foreach ($observations as $row) {
+            try {
+                $observed = new DateTimeImmutable($row['observedAt']);
+            } catch (\Exception) {
+                continue;
+            }
+            if ($observed > $at) {
+                continue;
+            }
+            $latest = (int) $row['boxOffice'];
+        }
+
+        return $latest;
+    }
+
+    public static function formatAmount(int $amount, bool $isJapan): string
+    {
+        $oku = $amount / 100_000_000;
+        if ($isJapan) {
+            return number_format($oku, 1).'億円';
+        }
+
+        return number_format($oku, 2).'億ドル';
+    }
+
+    public static function formatDelta(int $amount, bool $isJapan): string
+    {
+        return '+'.self::formatAmount($amount, $isJapan);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $observations
+     * @param  array<string, mixed>  $movie
+     * @return list<array<string, mixed>>
+     */
+    private static function milestones(
+        string $region,
+        array $movie,
+        array $observations,
+        ?string $releaseDate,
+        ?string $precision,
+    ): array {
+        $thresholds = $region === 'japan' ? self::JAPAN_MILESTONES : self::GLOBAL_MILESTONES;
+        $isJapan = $region === 'japan';
+        $reached = [];
+
+        foreach ($thresholds as $threshold) {
+            $hit = null;
+            foreach ($observations as $row) {
+                if ((int) $row['boxOffice'] >= $threshold) {
+                    $hit = $row;
+                    break;
+                }
+            }
+            if ($hit === null) {
+                continue;
+            }
+            $days = self::daysSinceRelease($releaseDate, $precision, new DateTimeImmutable($hit['observedAt']));
+            $reached[] = [
+                'key' => $movie['key'],
+                'title' => $movie['title'],
+                'threshold' => $threshold,
+                'label' => self::formatAmount($threshold, $isJapan).'突破',
+                'reachedAt' => $hit['observedAt'],
+                'daysToReach' => $days,
+            ];
+        }
+
+        return $reached;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $currentByKey
+     * @return list<array{key: string, title: string}>
+     */
+    private static function passedMovies(string $key, int $previous, int $current, array $currentByKey): array
+    {
+        $passed = [];
+        foreach ($currentByKey as $otherKey => $other) {
+            if ($otherKey === $key) {
+                continue;
+            }
+            $value = (int) $other['boxOffice'];
+            if ($value > $previous && $value <= $current) {
+                $passed[] = [
+                    'key' => $otherKey,
+                    'title' => $other['title'],
+                ];
+            }
+        }
+
+        return $passed;
+    }
+
+    /**
+     * @param  list<array{key: string, title: string}>  $passed
+     */
+    private static function passedLabel(array $passed): string
+    {
+        $names = array_map(fn (array $item) => '『'.$item['title'].'』', array_slice($passed, 0, 2));
+        $label = implode('と', $names).'を抜いた';
+        if (count($passed) > 2) {
+            $label .= ' ほか';
+        }
+
+        return $label;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $observations
+     * @return list<array{at: string, boxOffice: int}>
+     */
+    private static function sparkline(array $observations): array
+    {
+        $points = [];
+        foreach ($observations as $row) {
+            if (! empty($row['correction'])) {
+                continue;
+            }
+            $points[] = [
+                'at' => $row['observedAt'],
+                'boxOffice' => (int) $row['boxOffice'],
+            ];
+        }
+
+        return array_slice($points, -16);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $observations
+     */
+    private static function lastChangeAt(array $observations): ?string
+    {
+        if (count($observations) < 2) {
+            return null;
+        }
+
+        for ($i = count($observations) - 1; $i >= 1; $i--) {
+            if ((int) $observations[$i]['boxOffice'] !== (int) $observations[$i - 1]['boxOffice']) {
+                return $observations[$i]['observedAt'] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    private static function daysSinceRelease(?string $releaseDate, ?string $precision, DateTimeImmutable $at): ?int
+    {
+        if (! $releaseDate || $precision !== 'day') {
+            return null;
+        }
+
+        try {
+            $released = new DateTimeImmutable($releaseDate);
+        } catch (\Exception) {
+            return null;
+        }
+
+        $days = (int) floor(($at->getTimestamp() - $released->getTimestamp()) / 86400);
+
+        return max(0, $days);
+    }
+
+    private static function hoursBetween(DateTimeImmutable $from, DateTimeImmutable $to): float
+    {
+        return ($to->getTimestamp() - $from->getTimestamp()) / 3600;
+    }
+
+    private static function rankDeltaLabel(?int $rankDelta): ?string
+    {
+        if ($rankDelta === null || $rankDelta === 0) {
+            return null;
+        }
+
+        return $rankDelta > 0 ? $rankDelta.'位上昇' : abs($rankDelta).'位下降';
+    }
+}

--- a/app/Services/BoxOffice/MovieIdentity.php
+++ b/app/Services/BoxOffice/MovieIdentity.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\BoxOffice;
+
+class MovieIdentity
+{
+    public static function normalizeTitle(string $title): string
+    {
+        $title = mb_strtolower($title);
+        $title = mb_convert_kana($title, 'as');
+        $title = str_replace(['：', '﹕', '︰'], ':', $title);
+        $title = str_replace(['＆', '﹠'], '&', $title);
+        $title = str_replace(['Ⅱ', 'ii', 'II'], '2', $title);
+        $title = preg_replace('/[「」『』【】\[\]（）()・\/／\-–—_]/u', ' ', $title) ?? $title;
+        $title = preg_replace('/\s+/u', ' ', $title);
+
+        return trim((string) $title);
+    }
+
+    public static function japanKey(?int $tmdbId, string $normalizedTitle, ?int $year): string
+    {
+        if ($tmdbId) {
+            return 'jp-tmdb-'.$tmdbId;
+        }
+
+        return 'jp-'.substr(hash('sha256', $normalizedTitle.'|'.($year ?? '')), 0, 10);
+    }
+
+    public static function globalKey(int $tmdbId): string
+    {
+        return 'tmdb-'.$tmdbId;
+    }
+
+    public static function japanLegacyId(int $rank, string $title, string $distributor, string $wikipediaYearDate): string
+    {
+        return 'jp_'.sprintf('%03d', $rank).'_'.substr(md5($title.'|'.$distributor.'|'.$wikipediaYearDate), 0, 8);
+    }
+
+    public static function globalLegacyId(int $rank, int $tmdbId): string
+    {
+        return 'global_'.sprintf('%03d', $rank).'_'.$tmdbId;
+    }
+
+    public static function globalLegacySlug(int $rank, int $tmdbId): string
+    {
+        return sprintf('%03d', $rank).'_'.$tmdbId;
+    }
+
+    public static function regionFromKey(string $key): string
+    {
+        return str_starts_with($key, 'jp-') || str_starts_with($key, 'jp_') ? 'japan' : 'global';
+    }
+
+    public static function tmdbIdFromKey(string $key): ?int
+    {
+        if (preg_match('/^(?:jp-)?tmdb-(\d+)$/', $key, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    public static function japanHashFromLegacyId(string $legacyId): ?string
+    {
+        if (preg_match('/^jp_\d{3}_([0-9a-f]{8})$/', $legacyId, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/app/Services/BoxOffice/ObservationStore.php
+++ b/app/Services/BoxOffice/ObservationStore.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services\BoxOffice;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+
+class ObservationStore
+{
+    public function __construct(private readonly string $directory)
+    {
+    }
+
+    /**
+     * @param  array<string, mixed>  $observation
+     */
+    public function append(string $region, array $observation): bool
+    {
+        $observedAt = new DateTimeImmutable($observation['observedAt']);
+        $path = $this->monthPath($region, $observedAt);
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        $line = json_encode($observation, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        file_put_contents($path, $line."\n", FILE_APPEND | LOCK_EX);
+
+        return true;
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    public function loadByKey(string $region): array
+    {
+        $pattern = rtrim($this->directory, '/').'/'.$region.'/*.ndjson';
+        $files = glob($pattern) ?: [];
+        sort($files);
+
+        $byKey = [];
+        foreach ($files as $file) {
+            $handle = fopen($file, 'r');
+            if ($handle === false) {
+                continue;
+            }
+            while (($line = fgets($handle)) !== false) {
+                $line = trim($line);
+                if ($line === '') {
+                    continue;
+                }
+                $row = json_decode($line, true);
+                if (! is_array($row) || empty($row['key'])) {
+                    continue;
+                }
+                $byKey[$row['key']][] = $row;
+            }
+            fclose($handle);
+        }
+
+        foreach ($byKey as $key => $rows) {
+            usort($rows, fn (array $a, array $b) => strcmp($a['observedAt'] ?? '', $b['observedAt'] ?? ''));
+            $byKey[$key] = $this->collapseDuplicates($rows);
+        }
+
+        return $byKey;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    public function lastForKey(array $rows): ?array
+    {
+        if ($rows === []) {
+            return null;
+        }
+
+        return $rows[array_key_last($rows)];
+    }
+
+    /**
+     * @param  array<string, mixed>  $current
+     * @param  array<string, mixed>|null  $previous
+     */
+    public function shouldRecord(array $current, ?array $previous): bool
+    {
+        if ($previous === null) {
+            return true;
+        }
+
+        return (int) ($previous['boxOffice'] ?? 0) !== (int) ($current['boxOffice'] ?? 0)
+            || (bool) ($previous['isActive'] ?? false) !== (bool) ($current['isActive'] ?? false);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    private function collapseDuplicates(array $rows): array
+    {
+        $collapsed = [];
+        foreach ($rows as $row) {
+            $previous = $collapsed === [] ? null : $collapsed[array_key_last($collapsed)];
+            if ($previous
+                && (int) ($previous['boxOffice'] ?? 0) === (int) ($row['boxOffice'] ?? 0)
+                && (bool) ($previous['isActive'] ?? false) === (bool) ($row['isActive'] ?? false)
+                && empty($row['correction'])
+            ) {
+                continue;
+            }
+            $collapsed[] = $row;
+        }
+
+        return $collapsed;
+    }
+
+    private function monthPath(string $region, DateTimeInterface $observedAt): string
+    {
+        $tokyo = DateTimeImmutable::createFromInterface($observedAt)->setTimezone(new DateTimeZone('Asia/Tokyo'));
+
+        return rtrim($this->directory, '/').'/'.$region.'/'.$tokyo->format('Y-m').'.ndjson';
+    }
+}

--- a/app/Services/BoxOffice/Registry.php
+++ b/app/Services/BoxOffice/Registry.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Services\BoxOffice;
+
+class Registry
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $movies = [];
+
+    /** @var array<string, string> */
+    private array $aliases = [];
+
+    public function __construct(private readonly string $path)
+    {
+        $this->load();
+    }
+
+    public function load(): void
+    {
+        if (! is_file($this->path)) {
+            $this->movies = [];
+            $this->aliases = [];
+
+            return;
+        }
+
+        $decoded = json_decode((string) file_get_contents($this->path), true);
+        $this->movies = is_array($decoded['movies'] ?? null) ? $decoded['movies'] : [];
+        $this->aliases = is_array($decoded['aliases'] ?? null) ? $decoded['aliases'] : [];
+    }
+
+    public function save(): void
+    {
+        $directory = dirname($this->path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        $payload = json_encode([
+            'movies' => $this->movies,
+            'aliases' => $this->aliases,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        file_put_contents($this->path, $payload."\n", LOCK_EX);
+    }
+
+    public function resolveCanonicalKey(string $key): string
+    {
+        return $this->aliases[$key] ?? $key;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function get(string $key): ?array
+    {
+        $canonical = $this->resolveCanonicalKey($key);
+
+        return $this->movies[$canonical] ?? null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function movies(): array
+    {
+        return $this->movies;
+    }
+
+    /**
+     * @param  array{
+     *     region: string,
+     *     title: string,
+     *     tmdbId?: int|null,
+     *     releaseYear?: int|null,
+     *     releaseDate?: string|null,
+     *     releaseDatePrecision?: string|null,
+     *     legacyIds?: list<string>
+     * }  $incoming
+     * @return array<string, mixed>
+     */
+    public function resolve(array $incoming): array
+    {
+        $region = $incoming['region'];
+        $title = $incoming['title'];
+        $normalized = MovieIdentity::normalizeTitle($title);
+        $tmdbId = isset($incoming['tmdbId']) ? (int) $incoming['tmdbId'] : null;
+        if ($tmdbId === 0) {
+            $tmdbId = null;
+        }
+        $year = isset($incoming['releaseYear']) ? (int) $incoming['releaseYear'] : null;
+        $now = $incoming['now'] ?? gmdate('c');
+
+        $match = $this->findMatch($region, $tmdbId, $normalized, $year);
+        if ($match === null) {
+            $key = $region === 'japan'
+                ? MovieIdentity::japanKey($tmdbId, $normalized, $year)
+                : MovieIdentity::globalKey((int) $tmdbId);
+
+            $match = [
+                'key' => $key,
+                'region' => $region,
+                'title' => $title,
+                'normalizedTitle' => $normalized,
+                'releaseYear' => $year,
+                'releaseDate' => $incoming['releaseDate'] ?? null,
+                'releaseDatePrecision' => $incoming['releaseDatePrecision'] ?? ($year ? 'year' : null),
+                'tmdbId' => $tmdbId,
+                'legacyIds' => [],
+                'firstSeenAt' => $now,
+            ];
+        }
+
+        $match['title'] = $title;
+        $match['normalizedTitle'] = $normalized;
+        if ($tmdbId && empty($match['tmdbId'])) {
+            $match['tmdbId'] = $tmdbId;
+        }
+        if (! empty($incoming['releaseDate']) && ($incoming['releaseDatePrecision'] ?? '') === 'day') {
+            $match['releaseDate'] = $incoming['releaseDate'];
+            $match['releaseDatePrecision'] = 'day';
+            $match['releaseYear'] = (int) substr($incoming['releaseDate'], 0, 4);
+        } elseif ($year && empty($match['releaseYear'])) {
+            $match['releaseYear'] = $year;
+        }
+        if (! empty($incoming['releaseDate']) && empty($match['releaseDate'])) {
+            $match['releaseDate'] = $incoming['releaseDate'];
+            $match['releaseDatePrecision'] = $incoming['releaseDatePrecision'] ?? $match['releaseDatePrecision'] ?? null;
+        }
+
+        foreach ($incoming['legacyIds'] ?? [] as $legacyId) {
+            if ($legacyId === '' || $legacyId === $match['key']) {
+                continue;
+            }
+            $legacyIds = $match['legacyIds'] ?? [];
+            if (! in_array($legacyId, $legacyIds, true)) {
+                $legacyIds[] = $legacyId;
+            }
+            $match['legacyIds'] = $legacyIds;
+            $this->aliases[$legacyId] = $match['key'];
+        }
+
+        $this->movies[$match['key']] = $match;
+
+        return $match;
+    }
+
+    public function rememberLegacyId(string $key, string $legacyId): void
+    {
+        if ($legacyId === '' || $legacyId === $key) {
+            return;
+        }
+
+        $this->aliases[$legacyId] = $key;
+        $legacyIds = $this->movies[$key]['legacyIds'] ?? [];
+        if (! in_array($legacyId, $legacyIds, true)) {
+            $legacyIds[] = $legacyId;
+            $this->movies[$key]['legacyIds'] = $legacyIds;
+        }
+    }
+
+    /**
+     * @return list<array{from: string, to: string}>
+     */
+    public function redirects(): array
+    {
+        $rules = [];
+        foreach ($this->movies as $key => $movie) {
+            foreach ($movie['legacyIds'] ?? [] as $legacyId) {
+                $fromSlug = str_starts_with((string) $legacyId, 'global_')
+                    ? substr((string) $legacyId, strlen('global_'))
+                    : (string) $legacyId;
+                if ($fromSlug === $key) {
+                    continue;
+                }
+                $rules[] = [
+                    'from' => '/movies/'.$fromSlug,
+                    'to' => '/movies/'.$key.'/',
+                ];
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findMatch(string $region, ?int $tmdbId, string $normalizedTitle, ?int $year): ?array
+    {
+        if ($tmdbId) {
+            foreach ($this->movies as $movie) {
+                if (($movie['region'] ?? null) === $region && (int) ($movie['tmdbId'] ?? 0) === $tmdbId) {
+                    return $movie;
+                }
+            }
+        }
+
+        $candidates = [];
+        foreach ($this->movies as $movie) {
+            if (($movie['region'] ?? null) !== $region) {
+                continue;
+            }
+            if (($movie['normalizedTitle'] ?? '') !== $normalizedTitle) {
+                continue;
+            }
+            $candidates[] = $movie;
+        }
+
+        if ($candidates === []) {
+            return null;
+        }
+
+        if ($year) {
+            foreach ($candidates as $movie) {
+                if ((int) ($movie['releaseYear'] ?? 0) === $year) {
+                    return $movie;
+                }
+            }
+            foreach ($candidates as $movie) {
+                $existingYear = (int) ($movie['releaseYear'] ?? 0);
+                if ($existingYear && abs($existingYear - $year) <= 1) {
+                    return $movie;
+                }
+            }
+        }
+
+        return count($candidates) === 1 ? $candidates[0] : null;
+    }
+}

--- a/data/history/registry.json
+++ b/data/history/registry.json
@@ -1,0 +1,4 @@
+{
+    "movies": {},
+    "aliases": {}
+}

--- a/database/migrations/2026_08_14_000001_add_release_date_precision_to_movies_tables.php
+++ b/database/migrations/2026_08_14_000001_add_release_date_precision_to_movies_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('japanese_movies', function (Blueprint $table) {
+            if (! Schema::hasColumn('japanese_movies', 'release_date_precision')) {
+                $table->string('release_date_precision', 16)->nullable()->after('release_date');
+            }
+        });
+
+        Schema::table('global_movies', function (Blueprint $table) {
+            if (! Schema::hasColumn('global_movies', 'release_date_precision')) {
+                $table->string('release_date_precision', 16)->nullable()->after('release_date');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('japanese_movies', function (Blueprint $table) {
+            if (Schema::hasColumn('japanese_movies', 'release_date_precision')) {
+                $table->dropColumn('release_date_precision');
+            }
+        });
+
+        Schema::table('global_movies', function (Blueprint $table) {
+            if (Schema::hasColumn('global_movies', 'release_date_precision')) {
+                $table->dropColumn('release_date_precision');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_08_14_000002_add_is_active_to_global_movies_table.php
+++ b/database/migrations/2026_08_14_000002_add_is_active_to_global_movies_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('global_movies', function (Blueprint $table) {
+            if (! Schema::hasColumn('global_movies', 'is_active')) {
+                $table->boolean('is_active')->default(false)->after('rank');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('global_movies', function (Blueprint $table) {
+            if (Schema::hasColumn('global_movies', 'is_active')) {
+                $table->dropColumn('is_active');
+            }
+        });
+    }
+};

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
  */
 
 // キャッシュバージョン - デプロイ時に自動更新される
-const CACHE_VERSION = 'v20260101064500';
+const CACHE_VERSION = 'v20260814180000';
 const CACHE_NAME = `mubiran-cache-${CACHE_VERSION}`;
 
 // キャッシュするスタティックアセット

--- a/resources/css/now-playing.css
+++ b/resources/css/now-playing.css
@@ -1,0 +1,102 @@
+.now-page { margin: 0 auto 48px; max-width: 960px; }
+.now-lead, .now-disclaimer, .now-banner p, .now-today p, .now-empty {
+    color: var(--text-secondary);
+    line-height: 1.7;
+}
+.now-lead { margin-bottom: 24px; text-align: center; }
+.now-banner, .now-today, .now-milestones {
+    background: var(--bg-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 18px 20px;
+    margin-bottom: 20px;
+}
+.now-banner h2, .now-today h2, .now-milestones h2 {
+    font-size: 1rem;
+    margin-bottom: 8px;
+}
+.now-banner ul, .now-today ul, .now-milestones ul { padding-left: 1.1rem; }
+.now-banner li, .now-today li, .now-milestones li { margin: 6px 0; }
+.now-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+.now-region { display: flex; gap: 8px; }
+.now-chip, .now-sort select {
+    background: #222;
+    color: #fff;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    padding: 8px 14px;
+    cursor: pointer;
+}
+.now-chip.active { background: #444; }
+.now-sort { color: var(--text-secondary); font-size: .9rem; display: flex; align-items: center; gap: 8px; }
+.now-board { display: flex; flex-direction: column; gap: 12px; }
+.now-card {
+    display: grid;
+    grid-template-columns: 72px 1fr;
+    gap: 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 14px;
+    cursor: pointer;
+}
+.now-card.is-active { border-color: rgba(46, 204, 113, .55); }
+.now-card:hover { border-color: rgba(255,255,255,.3); }
+.now-poster {
+    width: 72px;
+    height: 108px;
+    border-radius: 8px;
+    background: #333 center/cover no-repeat;
+}
+.now-poster-empty { background: #2a2a2a; }
+.now-title { font-size: 1.05rem; margin-bottom: 8px; }
+.now-unread, .now-pill {
+    display: inline-block;
+    font-size: .65rem;
+    padding: 2px 6px;
+    border-radius: 999px;
+    margin-left: 6px;
+    vertical-align: middle;
+}
+.now-unread { background: #e50914; color: #fff; }
+.now-pill-active { background: rgba(46, 204, 113, .2); color: #2ecc71; }
+.now-metrics, .now-card-bottom {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+    color: var(--text-secondary);
+    font-size: .85rem;
+}
+.now-metrics { margin-bottom: 10px; }
+.now-delta { color: #4ade80; font-weight: 700; }
+.now-delta-muted { color: var(--text-secondary); font-weight: 500; }
+.now-total { font-family: var(--font-num); font-size: 1.15rem; color: var(--accent-gold); }
+.now-passed { margin-top: 4px; font-size: .85rem; }
+.now-permalink { color: var(--accent-blue); font-size: .8rem; }
+.now-card-top { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+.now-sparkline { color: #fbbf24; flex-shrink: 0; }
+.now-disclaimer { margin-top: 28px; font-size: .85rem; }
+.momentum-badge {
+    display: inline-block;
+    margin-top: 4px;
+    color: #4ade80;
+    font-size: .75rem;
+    font-weight: 700;
+}
+
+@media (max-width: 768px) {
+    .list-item .momentum-badge,
+    .top-card .momentum-badge { display: none; }
+    .now-card { grid-template-columns: 52px 1fr; gap: 10px; }
+    .now-poster { width: 52px; height: 78px; }
+    .now-title { font-size: .95rem; }
+    .toggle-btn { padding: 8px 12px; font-size: .8rem; }
+}

--- a/resources/js/now-playing.js
+++ b/resources/js/now-playing.js
@@ -1,0 +1,194 @@
+import '../css/now-playing.css';
+
+const VISIT_KEY = 'mubiran.now.v1';
+
+export const escapeHtml = (value = '') => String(value).replace(/[&<>'"]/g, (char) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;',
+}[char]));
+
+export function sparklineSvg(points = []) {
+    if (points.length < 2) {
+        return '<span class="now-sparkline now-sparkline-empty" aria-hidden="true"></span>';
+    }
+    const values = points.map((point) => Number(point.boxOffice) || 0);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const span = Math.max(1, max - min);
+    const width = 84;
+    const height = 28;
+    const coords = values.map((value, index) => {
+        const x = (index / (values.length - 1)) * width;
+        const y = height - ((value - min) / span) * (height - 4) - 2;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+    });
+    return `<svg class="now-sparkline" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" aria-hidden="true"><polyline fill="none" stroke="currentColor" stroke-width="2" points="${coords.join(' ')}"/></svg>`;
+}
+
+export function readVisit() {
+    try {
+        return JSON.parse(localStorage.getItem(VISIT_KEY) || 'null');
+    } catch {
+        return null;
+    }
+}
+
+export function writeVisit(movies) {
+    const totals = {};
+    movies.forEach((movie) => {
+        totals[movie.key] = movie.boxOffice;
+    });
+    localStorage.setItem(VISIT_KEY, JSON.stringify({
+        visitAt: new Date().toISOString(),
+        totals,
+    }));
+}
+
+export function visitDiffs(movies, previous) {
+    if (!previous?.totals) return [];
+
+    return movies
+        .map((movie) => {
+            const before = previous.totals[movie.key];
+            if (typeof before !== 'number' || movie.boxOffice <= before) return null;
+            return {
+                ...movie,
+                visitDelta: movie.boxOffice - before,
+                visitDeltaLabel: movie.region === 'global'
+                    ? `+${((movie.boxOffice - before) / 100000000).toFixed(2)}億ドル`
+                    : `+${((movie.boxOffice - before) / 100000000).toFixed(1)}億円`,
+            };
+        })
+        .filter(Boolean)
+        .sort((left, right) => right.visitDelta - left.visitDelta);
+}
+
+function formatVisitAt(iso) {
+    if (!iso) return '';
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '';
+    return `${date.getMonth() + 1}/${date.getDate()} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function sortMovies(movies, sort) {
+    const copy = [...movies];
+    copy.sort((left, right) => {
+        switch (sort) {
+        case 'pace':
+            return (right.dailyPace || -1) - (left.dailyPace || -1);
+        case 'total':
+            return right.boxOffice - left.boxOffice;
+        case 'rank':
+            return (right.rankDelta || -999) - (left.rankDelta || -999);
+        case 'days':
+            return (left.daysSinceRelease ?? 9999) - (right.daysSinceRelease ?? 9999);
+        default:
+            return (right.delta || -1) - (left.delta || -1);
+        }
+    });
+    return copy;
+}
+
+function movieHref(movie) {
+    return `/movies/${encodeURIComponent(movie.slug || movie.key)}/`;
+}
+
+function boardCard(movie, unreadKeys) {
+    const unread = unreadKeys.has(movie.key) ? '<span class="now-unread">更新</span>' : '';
+    const active = movie.isActive ? '<span class="now-pill now-pill-active">公開中</span>' : '';
+    const delta = movie.deltaLabel
+        ? `<span class="now-delta">${escapeHtml(movie.deltaLabel)}</span>`
+        : '<span class="now-delta now-delta-muted">伸び待ち</span>';
+    const pace = movie.dailyPaceLabel ? `<span>${escapeHtml(movie.dailyPaceLabel)}</span>` : '';
+    const days = movie.daysSincePrev ? `<span>${movie.daysSincePrev}日前の発表比</span>` : '';
+    const rank = movie.rank ? `<span>歴代${movie.rank}位</span>` : '';
+    const rankDelta = movie.rankDeltaLabel ? `<span>${escapeHtml(movie.rankDeltaLabel)}</span>` : '';
+    const released = movie.daysSinceRelease != null ? `<span>公開${movie.daysSinceRelease}日目</span>` : '';
+    const passed = movie.passedLabel ? `<p class="now-passed">${escapeHtml(movie.passedLabel)}</p>` : '';
+    const poster = movie.posterUrl
+        ? `<div class="now-poster" style="background-image:url('${escapeHtml(movie.posterUrl)}')"></div>`
+        : '<div class="now-poster now-poster-empty"></div>';
+
+    return `<article class="now-card ${movie.isActive ? 'is-active' : ''}" data-movie-id="${escapeHtml(movie.key)}" role="button" tabindex="0" aria-label="${escapeHtml(movie.title)}の詳細">
+        ${poster}
+        <div class="now-card-body">
+            <div class="now-card-top">
+                <h3 class="now-title">${escapeHtml(movie.title)} ${unread}${active}</h3>
+                <a class="now-permalink" href="${movieHref(movie)}" onclick="event.stopPropagation()">作品ページ</a>
+            </div>
+            <div class="now-metrics">
+                ${delta}${pace}${days}${rank}${rankDelta}${released}
+            </div>
+            <div class="now-card-bottom">
+                <div>
+                    <div class="now-total">${escapeHtml(movie.revenueLabel || movie.revenue || '')}</div>
+                    ${passed}
+                </div>
+                ${sparklineSvg(movie.sparkline)}
+            </div>
+        </div>
+    </article>`;
+}
+
+export function renderNowPlaying(data, state, visit) {
+    const region = state.nowRegion === 'global' ? 'global' : 'japan';
+    const bucket = data[region] || { board: [], today: [], milestones: [] };
+    const sorted = sortMovies(bucket.board || [], state.nowSort || 'delta');
+    const diffs = visitDiffs(sorted, visit);
+    const unreadKeys = new Set(diffs.map((item) => item.key));
+    const lastVisitLabel = visit?.visitAt ? formatVisitAt(visit.visitAt) : '';
+
+    const banner = diffs.length
+        ? `<section class="now-banner">
+            <h2>前回から伸びた作品</h2>
+            <p>前回訪問（${escapeHtml(lastVisitLabel)}）からの累計差です。</p>
+            <ul>${diffs.slice(0, 6).map((item) => `<li><strong>${escapeHtml(item.title)}</strong> ${escapeHtml(item.visitDeltaLabel)}</li>`).join('')}</ul>
+        </section>`
+        : (visit
+            ? '<section class="now-banner now-banner-quiet"><p>前回訪問から、数字の動いた作品はありません。次の発表を待っています。</p></section>'
+            : '<section class="now-banner now-banner-quiet"><p>このブラウザで次回訪れたときに、前回からの変化を表示します。</p></section>');
+
+    const today = (bucket.today || []).length
+        ? `<section class="now-today"><h2>直近の発表</h2><ul>${bucket.today.map((item) => `<li><strong>${escapeHtml(item.title)}</strong> ${escapeHtml(item.deltaLabel || '')} ${escapeHtml(item.dailyPaceLabel || '')}</li>`).join('')}</ul></section>`
+        : '<section class="now-today"><h2>直近の発表</h2><p>直近72時間で新しい発表はありません。</p></section>';
+
+    const milestones = (bucket.milestones || []).length
+        ? `<section class="now-milestones"><h2>最近の到達</h2><ul>${bucket.milestones.map((item) => `<li><strong>${escapeHtml(item.title)}</strong> ${escapeHtml(item.label)}${item.daysToReach != null ? `（公開${item.daysToReach}日目）` : ''} <small>発表ベース</small></li>`).join('')}</ul></section>`
+        : '';
+
+    const empty = sorted.length
+        ? sorted.map((movie) => boardCard(movie, unreadKeys)).join('')
+        : '<p class="now-empty">いま動いている作品はまだありません。公開中フラグ、または直近30日で数字が動いた作品がここに並びます。</p>';
+
+    return `<div class="now-page">
+        <p class="now-lead">公開中の作品が、どれくらいの勢いで伸びているかを追う板です。日本の興収は配給発表ベースのため、毎日は動きません。</p>
+        ${banner}
+        <div class="now-toolbar">
+            <div class="now-region" role="group" aria-label="対象">
+                <button type="button" class="now-chip ${region === 'japan' ? 'active' : ''}" data-now-region="japan">日本</button>
+                <button type="button" class="now-chip ${region === 'global' ? 'active' : ''}" data-now-region="global">世界</button>
+            </div>
+            <label class="now-sort">並び替え
+                <select data-now-sort>
+                    <option value="delta" ${state.nowSort === 'delta' ? 'selected' : ''}>伸び額</option>
+                    <option value="pace" ${state.nowSort === 'pace' ? 'selected' : ''}>1日ペース</option>
+                    <option value="total" ${state.nowSort === 'total' ? 'selected' : ''}>累計興収</option>
+                    <option value="rank" ${state.nowSort === 'rank' ? 'selected' : ''}>順位上昇</option>
+                    <option value="days" ${state.nowSort === 'days' ? 'selected' : ''}>公開日が新しい</option>
+                </select>
+            </label>
+        </div>
+        ${today}
+        ${milestones}
+        <section class="now-board" aria-label="公開中の勢い">${empty}</section>
+        <p class="now-disclaimer">${escapeHtml(data.disclaimer || '')}</p>
+    </div>`;
+}
+
+export function bindNowPlaying(root, onChange) {
+    root.querySelectorAll('[data-now-region]').forEach((button) => {
+        button.addEventListener('click', () => onChange({ nowRegion: button.dataset.nowRegion }));
+    });
+    root.querySelector('[data-now-sort]')?.addEventListener('change', (event) => {
+        onChange({ nowSort: event.target.value });
+    });
+}

--- a/resources/js/static-site.js
+++ b/resources/js/static-site.js
@@ -11,10 +11,19 @@ import {
     renderFilterModal,
     updateFilterBadges,
 } from './static-filters';
+import {
+    bindNowPlaying,
+    readVisit,
+    renderNowPlaying,
+    writeVisit,
+} from './now-playing';
 
 const PER_PAGE = 100;
 const app = document.querySelector('#app');
 let siteData = null;
+let nowPlayingData = null;
+let nowPlayingRequest = null;
+let visitRecorded = false;
 
 const defaultState = () => ({
     tab: 'global',
@@ -24,6 +33,8 @@ const defaultState = () => ({
     matchMode: 'and',
     globalPage: 1,
     japanPage: 1,
+    nowRegion: 'japan',
+    nowSort: 'delta',
 });
 
 const state = defaultState();
@@ -80,7 +91,16 @@ const aiOverlay = (analysis) => {
 function parseStateFromUrl() {
     const params = new URLSearchParams(window.location.search);
     const next = defaultState();
-    next.tab = params.get('tab') === 'japan' ? 'japan' : 'global';
+    const path = window.location.pathname.replace(/\/+$/, '') || '/';
+    if (path === '/now') {
+        next.tab = 'now';
+    } else if (params.get('tab') === 'japan' || params.get('tab') === 'now') {
+        next.tab = params.get('tab');
+    } else {
+        next.tab = 'global';
+    }
+    next.nowRegion = params.get('now_region') === 'global' ? 'global' : 'japan';
+    next.nowSort = ['pace', 'total', 'rank', 'days'].includes(params.get('now_sort')) ? params.get('now_sort') : 'delta';
     next.category = params.get('category') || 'all';
     next.genres = params.get('genres') ? params.get('genres').split(',').filter(Boolean) : [];
     next.years = params.get('years') ? params.get('years').split(',').filter(Boolean) : [];
@@ -91,8 +111,17 @@ function parseStateFromUrl() {
 }
 
 function buildUrl(nextState) {
+    if (nextState.tab === 'now' && (window.location.pathname.replace(/\/+$/, '') === '/now')) {
+        const params = new URLSearchParams();
+        if (nextState.nowRegion !== 'japan') params.set('now_region', nextState.nowRegion);
+        if (nextState.nowSort !== 'delta') params.set('now_sort', nextState.nowSort);
+        const query = params.toString();
+        return query ? `/now/?${query}` : '/now/';
+    }
     const params = new URLSearchParams();
     if (nextState.tab && nextState.tab !== 'global') params.set('tab', nextState.tab);
+    if (nextState.tab === 'now' && nextState.nowRegion !== 'japan') params.set('now_region', nextState.nowRegion);
+    if (nextState.tab === 'now' && nextState.nowSort !== 'delta') params.set('now_sort', nextState.nowSort);
     if (nextState.category && nextState.category !== 'all') params.set('category', nextState.category);
     if (nextState.genres.length) params.set('genres', nextState.genres.join(','));
     if (nextState.years.length) params.set('years', nextState.years.join(','));
@@ -147,6 +176,7 @@ function movieCard(movie) {
         <div class="revenue-container">
             <div class="revenue-main" style="color: var(--accent-gold);">${escapeHtml(movie.revenue)}</div>
             ${movie.revenueYen ? `<div class="revenue-sub">${escapeHtml(movie.revenueYen)}</div>` : ''}
+            ${movie.momentum?.deltaLabel ? `<div class="momentum-badge">${escapeHtml(movie.momentum.deltaLabel)}</div>` : ''}
         </div>
         ${aiOverlay(movie.analysis)}
     </article>`;
@@ -170,6 +200,7 @@ function movieRow(movie, isJapan) {
         <div class="list-revenue">
             <span class="revenue-main">${escapeHtml(movie.revenue)}</span>
             ${movie.revenueYen ? `<span class="revenue-sub">${escapeHtml(movie.revenueYen)}</span>` : ''}
+            ${movie.momentum?.deltaLabel ? `<span class="momentum-badge">${escapeHtml(movie.momentum.deltaLabel)}</span>` : ''}
         </div>
         ${aiOverlay(movie.analysis)}
     </article>`;
@@ -196,9 +227,12 @@ function renderPagination(totalItems) {
 }
 
 function findMovie(data, movieId) {
-    return data[state.tab].find((movie) => movie.id === movieId)
-        || [...data.global, ...data.japan].find((movie) => movie.id === movieId)
-        || null;
+    const pools = [...(data.global || []), ...(data.japan || [])];
+    const fromRankings = pools.find((movie) => movie.id === movieId);
+    if (fromRankings) return fromRankings;
+    const boards = [...(nowPlayingData?.japan?.board || []), ...(nowPlayingData?.global?.board || [])];
+    const fromBoard = boards.find((movie) => movie.key === movieId || movie.id === movieId);
+    return fromBoard ? { ...fromBoard, id: fromBoard.key || fromBoard.id } : null;
 }
 
 function bindAiOverlays() {
@@ -246,6 +280,7 @@ function bindMovieInteractions(data) {
 }
 
 function renderFilterTrigger() {
+    if (state.tab === 'now') return '';
     return `<button type="button" class="filter-trigger-btn filter-mobile" aria-label="絞り込み">
         <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/>
@@ -254,13 +289,100 @@ function renderFilterTrigger() {
     </button>`;
 }
 
+function headerHtml() {
+    const desktopFilter = state.tab === 'now' ? '' : `<button type="button" class="filter-trigger-btn filter-desktop" aria-label="絞り込み">
+        <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/>
+        </svg>
+        <span class="filter-text">絞り込み</span>
+    </button>`;
+    return `<header>
+        <a href="/" class="logo-link" aria-label="MUBIRAN トップ"><img src="/images/logo.png" alt="MUBIRAN" class="logo-img"></a>
+        <div class="header-controls">
+            <div class="toggle-container">
+                <a href="/" class="toggle-btn ${state.tab === 'global' ? 'active' : ''}" data-tab="global" id="btn-global">世界</a>
+                <a href="/?tab=japan" class="toggle-btn ${state.tab === 'japan' ? 'active' : ''}" data-tab="japan" id="btn-japan">日本</a>
+                <a href="/now/" class="toggle-btn ${state.tab === 'now' ? 'active' : ''}" data-tab="now" id="btn-now">公開中</a>
+            </div>
+            ${renderFilterTrigger()}
+        </div>
+        ${desktopFilter}
+    </header>`;
+}
+
+function footerHtml() {
+    return `<footer><div class="container"><p class="site-footer-links"><a href="/now/">公開中の動向</a> · <a href="/about/">このサイトについて</a> · <a href="/privacy/">プライバシーポリシー</a> · <a href="/feed.xml">RSS</a></p><p>&copy; ${new Date().getFullYear()} MUBIRAN. All rights reserved.</p><p>Data provided by <a href="https://www.themoviedb.org/" target="_blank" rel="noreferrer">TMDb</a> and <a href="https://ja.wikipedia.org/" target="_blank" rel="noreferrer">Wikipedia</a>.</p></div></footer>`;
+}
+
+function ensureNowPlaying() {
+    if (nowPlayingData) return Promise.resolve(nowPlayingData);
+    if (!nowPlayingRequest) {
+        nowPlayingRequest = fetch('/data/now-playing.json')
+            .then((response) => (response.ok ? response.json() : Promise.reject(new Error('公開中データを読み込めませんでした。'))))
+            .then((json) => {
+                nowPlayingData = json;
+                return json;
+            });
+    }
+    return nowPlayingRequest;
+}
+
 function switchTab(tab, { updateHistory = true } = {}) {
     state.tab = tab;
     if (updateHistory) syncUrl();
+    if (tab === 'now') {
+        ensureNowPlaying()
+            .then(() => render(siteData))
+            .catch((error) => { app.innerHTML = `<p class="static-error">${escapeHtml(error.message)}</p>`; });
+        return;
+    }
     render(siteData);
 }
 
+function renderNowBoard(data) {
+    const visit = readVisit();
+    const title = '公開中の興行収入';
+    app.innerHTML = `${headerHtml()}
+    <main class="container">
+        <h1 class="page-title">${title}</h1>
+        ${renderNowPlaying(nowPlayingData, state, visit)}
+    </main>
+    ${footerHtml()}`;
+
+    document.querySelectorAll('[data-tab]').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            switchTab(button.dataset.tab);
+        });
+    });
+    bindNowPlaying(app, (next) => {
+        Object.assign(state, next);
+        syncUrl();
+        render(data);
+    });
+    bindMovieInteractions(data);
+    const boardMovies = [
+        ...(nowPlayingData.japan?.board || []),
+        ...(nowPlayingData.global?.board || []),
+    ];
+    if (!visitRecorded) {
+        writeVisit(boardMovies);
+        visitRecorded = true;
+    }
+}
+
 function render(data) {
+    if (state.tab === 'now') {
+        if (!nowPlayingData) {
+            ensureNowPlaying()
+                .then(() => render(data))
+                .catch((error) => { app.innerHTML = `<p class="static-error">${escapeHtml(error.message)}</p>`; });
+            return;
+        }
+        renderNowBoard(data);
+        return;
+    }
+
     const allGenres = [...new Set([...data.global, ...data.japan].flatMap((movie) => movie.genres || []))]
         .filter((genre) => genre !== 'アニメーション' && genre !== 'アニメ')
         .sort((a, b) => a.localeCompare(b, 'ja'));
@@ -281,22 +403,7 @@ function render(data) {
     const title = isJapan ? '日本興行収入ランキング' : '世界興行収入ランキング';
     const lastUpdated = isJapan ? data.japanLastUpdated : data.globalLastUpdated;
 
-    app.innerHTML = `<header>
-        <a href="/" class="logo-link" aria-label="MUBIRAN トップ"><img src="/images/logo.png" alt="MUBIRAN" class="logo-img"></a>
-        <div class="header-controls">
-            <div class="toggle-container">
-                <a href="#" class="toggle-btn ${state.tab === 'global' ? 'active' : ''}" data-tab="global" id="btn-global">世界興行収入</a>
-                <a href="#" class="toggle-btn ${state.tab === 'japan' ? 'active' : ''}" data-tab="japan" id="btn-japan">日本興行収入</a>
-            </div>
-            ${renderFilterTrigger()}
-        </div>
-        <button type="button" class="filter-trigger-btn filter-desktop" aria-label="絞り込み">
-            <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/>
-            </svg>
-            <span class="filter-text">絞り込み</span>
-        </button>
-    </header>
+    app.innerHTML = `${headerHtml()}
     <main class="container">
         <h1 class="page-title" id="page-title">${title}</h1>
         ${movies.length
@@ -305,7 +412,7 @@ function render(data) {
         ${lastUpdated ? `<div class="text-center mt-4 mb-5"><small class="static-updated">最終更新: ${escapeHtml(lastUpdated)}</small></div>` : ''}
         <div class="d-flex justify-content-center mt-4">${renderPagination(totalItems)}</div>
     </main>
-    <footer><div class="container"><p class="site-footer-links"><a href="/about/">このサイトについて</a> · <a href="/privacy/">プライバシーポリシー</a></p><p>&copy; ${new Date().getFullYear()} MUBIRAN. All rights reserved.</p><p>Data provided by <a href="https://www.themoviedb.org/" target="_blank" rel="noreferrer">TMDb</a> and <a href="https://ja.wikipedia.org/" target="_blank" rel="noreferrer">Wikipedia</a>.</p></div></footer>
+    ${footerHtml()}
     ${renderFilterModal(allGenres, state)}`;
 
     document.querySelectorAll('[data-tab]').forEach((button) => {

--- a/tests/Unit/BoxOffice/BoxOfficeHistoryTest.php
+++ b/tests/Unit/BoxOffice/BoxOfficeHistoryTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Tests\Unit\BoxOffice;
+
+use App\Services\BoxOffice\HistoryRecorder;
+use App\Services\BoxOffice\Insights;
+use App\Services\BoxOffice\MovieIdentity;
+use App\Services\BoxOffice\ObservationStore;
+use App\Services\BoxOffice\Registry;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class BoxOfficeHistoryTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir().'/boxoffice-'.bin2hex(random_bytes(4));
+        mkdir($this->dir.'/observations/japan', 0777, true);
+        mkdir($this->dir.'/observations/global', 0777, true);
+        file_put_contents($this->dir.'/registry.json', '{"movies":{},"aliases":{}}');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    public function test_identity_keys_are_stable_and_independent_of_rank(): void
+    {
+        $normalized = MovieIdentity::normalizeTitle('君の名は。');
+        $this->assertSame('jp-tmdb-372058', MovieIdentity::japanKey(372058, $normalized, 2016));
+        $this->assertSame(
+            MovieIdentity::japanKey(null, $normalized, 2016),
+            MovieIdentity::japanKey(null, $normalized, 2016),
+        );
+        $this->assertSame('tmdb-19995', MovieIdentity::globalKey(19995));
+        $this->assertNotSame(
+            MovieIdentity::japanLegacyId(12, '君の名は。', '東宝', '2016-01-01'),
+            MovieIdentity::japanLegacyId(5, '君の名は。', '東宝', '2016-01-01'),
+        );
+    }
+
+    public function test_registry_reuses_tmdb_match_when_title_changes(): void
+    {
+        $registry = new Registry($this->dir.'/registry.json');
+        $first = $registry->resolve([
+            'region' => 'japan',
+            'title' => '君の名は。',
+            'tmdbId' => 372058,
+            'releaseYear' => 2016,
+            'legacyIds' => ['jp_012_aaaaaaaa'],
+        ]);
+        $second = $registry->resolve([
+            'region' => 'japan',
+            'title' => '君の名は',
+            'tmdbId' => 372058,
+            'releaseYear' => 2016,
+            'legacyIds' => ['jp_008_bbbbbbbb'],
+        ]);
+
+        $this->assertSame($first['key'], $second['key']);
+        $this->assertContains('jp_012_aaaaaaaa', $second['legacyIds']);
+        $this->assertContains('jp_008_bbbbbbbb', $second['legacyIds']);
+    }
+
+    public function test_registry_matches_title_and_nearby_year_without_tmdb(): void
+    {
+        $registry = new Registry($this->dir.'/registry.json');
+        $first = $registry->resolve([
+            'region' => 'japan',
+            'title' => 'テスト映画',
+            'releaseYear' => 2024,
+        ]);
+        $second = $registry->resolve([
+            'region' => 'japan',
+            'title' => 'テスト映画',
+            'releaseYear' => 2025,
+        ]);
+
+        $this->assertSame($first['key'], $second['key']);
+        $this->assertStringStartsWith('jp-', $first['key']);
+        $this->assertStringStartsNotWith('jp-tmdb-', $first['key']);
+    }
+
+    public function test_observations_skip_unchanged_values_and_flag_corrections(): void
+    {
+        $recorder = HistoryRecorder::fromBasePath($this->dir);
+        $movie = $this->japanMovie('jp-tmdb-1', '作品A', 5_000_000_000, true);
+        $recorder->resolve([
+            'region' => 'japan',
+            'title' => '作品A',
+            'tmdbId' => 1,
+            'releaseYear' => 2024,
+            'legacyIds' => ['jp_001_oldhash'],
+        ]);
+
+        $recorder->recordSnapshot('japan', [$movie], new DateTimeImmutable('2026-08-01T03:00:00+09:00'));
+        $recorder->recordSnapshot('japan', [$movie], new DateTimeImmutable('2026-08-01T09:00:00+09:00'));
+
+        $grown = $this->japanMovie('jp-tmdb-1', '作品A', 5_800_000_000, true);
+        $recorder->recordSnapshot('japan', [$grown], new DateTimeImmutable('2026-08-07T03:00:00+09:00'));
+
+        $corrected = $this->japanMovie('jp-tmdb-1', '作品A', 5_700_000_000, true);
+        $recorder->recordSnapshot('japan', [$corrected], new DateTimeImmutable('2026-08-08T03:00:00+09:00'));
+
+        $rows = (new ObservationStore($this->dir.'/observations'))->loadByKey('japan')['jp-tmdb-1'];
+        $this->assertCount(3, $rows);
+        $this->assertTrue($rows[2]['correction']);
+        $this->assertSame(5_000_000_000, $rows[0]['boxOffice']);
+        $this->assertSame(5_800_000_000, $rows[1]['boxOffice']);
+    }
+
+    public function test_insights_compute_pace_rank_pass_and_board_membership(): void
+    {
+        $now = new DateTimeImmutable('2026-08-14T12:00:00+09:00');
+        $observations = [
+            'jp-a' => [
+                $this->obs('jp-a', '2026-08-01T03:00:00+09:00', 4_000_000_000, true),
+                $this->obs('jp-a', '2026-08-08T03:00:00+09:00', 5_200_000_000, true),
+            ],
+            'jp-b' => [
+                $this->obs('jp-b', '2026-07-01T03:00:00+09:00', 4_500_000_000, false),
+                $this->obs('jp-b', '2026-07-10T03:00:00+09:00', 4_600_000_000, false),
+            ],
+            'jp-c' => [
+                $this->obs('jp-c', '2026-07-01T03:00:00+09:00', 8_000_000_000, false),
+            ],
+            'jp-d' => [
+                $this->obs('jp-d', '2026-07-20T03:00:00+09:00', 3_000_000_000, true),
+                $this->obs('jp-d', '2026-08-05T03:00:00+09:00', 3_400_000_000, true),
+            ],
+        ];
+
+        $current = [
+            $this->current('jp-a', '伸びてる映画', 5_200_000_000, true),
+            $this->current('jp-b', '抜かれた映画', 4_600_000_000, false),
+            $this->current('jp-c', '不動の上位', 8_000_000_000, false),
+        ];
+
+        $result = Insights::compute('japan', $current, $observations, [
+            'jp-a' => ['releaseDate' => '2026-06-20', 'releaseDatePrecision' => 'day'],
+        ], $now);
+
+        $this->assertTrue($result['movies']['jp-a']['onBoard']);
+        $this->assertFalse($result['movies']['jp-c']['onBoard']);
+        $this->assertSame(1_200_000_000, $result['movies']['jp-a']['delta']);
+        $this->assertSame('+12.0億円', $result['movies']['jp-a']['deltaLabel']);
+        $this->assertSame(7, $result['movies']['jp-a']['daysSincePrev']);
+        $this->assertSame('jp-b', $result['movies']['jp-a']['passed'][0]['key']);
+        $this->assertSame(2, $result['movies']['jp-a']['rank']);
+        $this->assertNotEmpty($result['movies']['jp-a']['milestones']);
+        $this->assertSame('jp-a', $result['board'][0]['key']);
+        $this->assertTrue($result['movies']['jp-d']['onBoard']);
+        $this->assertContains('jp-d', array_column($result['board'], 'key'));
+    }
+
+    public function test_negative_or_correction_deltas_are_hidden(): void
+    {
+        $observations = [
+            $this->obs('jp-a', '2026-08-01T03:00:00+09:00', 5_000_000_000, true),
+            $this->obs('jp-a', '2026-08-08T03:00:00+09:00', 4_800_000_000, true, true),
+        ];
+        $growth = Insights::growth($observations);
+        $this->assertNull($growth['delta']);
+    }
+
+    public function test_redirects_are_emitted_from_legacy_ids(): void
+    {
+        $registry = new Registry($this->dir.'/registry.json');
+        $registry->resolve([
+            'region' => 'global',
+            'title' => 'Avatar',
+            'tmdbId' => 19995,
+            'releaseYear' => 2009,
+            'legacyIds' => ['global_001_19995'],
+        ]);
+        $rules = $registry->redirects();
+        $this->assertSame('/movies/001_19995', $rules[0]['from']);
+        $this->assertSame('/movies/tmdb-19995/', $rules[0]['to']);
+    }
+
+    public function test_disappeared_active_movie_is_closed_in_history(): void
+    {
+        $recorder = HistoryRecorder::fromBasePath($this->dir);
+        $recorder->resolve([
+            'region' => 'japan',
+            'title' => '公開終了映画',
+            'tmdbId' => 9,
+            'releaseYear' => 2026,
+        ]);
+        $movie = $this->japanMovie('jp-tmdb-9', '公開終了映画', 2_000_000_000, true);
+        $recorder->recordSnapshot('japan', [$movie], new DateTimeImmutable('2026-08-01T03:00:00+09:00'));
+        $warnings = $recorder->recordSnapshot('japan', [], new DateTimeImmutable('2026-08-08T03:00:00+09:00'));
+
+        $rows = (new ObservationStore($this->dir.'/observations'))->loadByKey('japan')['jp-tmdb-9'];
+        $this->assertNotEmpty($warnings);
+        $this->assertCount(2, $rows);
+        $this->assertFalse($rows[1]['isActive']);
+        $this->assertSame(2_000_000_000, $rows[1]['boxOffice']);
+    }
+
+    public function test_stable_keys_can_be_parsed_from_identity(): void
+    {
+        $this->assertSame(19995, MovieIdentity::tmdbIdFromKey('tmdb-19995'));
+        $this->assertSame(372058, MovieIdentity::tmdbIdFromKey('jp-tmdb-372058'));
+        $this->assertNull(MovieIdentity::tmdbIdFromKey('jp-abcdef1234'));
+        $this->assertSame(
+            'aaaaaaaa',
+            MovieIdentity::japanHashFromLegacyId('jp_012_aaaaaaaa')
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function japanMovie(string $key, string $title, int $boxOffice, bool $isActive): array
+    {
+        return [
+            'movie_id' => $key,
+            'title' => $title,
+            'box_office' => $boxOffice,
+            'is_active' => $isActive,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function current(string $key, string $title, int $boxOffice, bool $isActive): array
+    {
+        return [
+            'key' => $key,
+            'title' => $title,
+            'boxOffice' => $boxOffice,
+            'isActive' => $isActive,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function obs(string $key, string $at, int $boxOffice, bool $isActive, bool $correction = false): array
+    {
+        $row = [
+            'key' => $key,
+            'observedAt' => $at,
+            'boxOffice' => $boxOffice,
+            'isActive' => $isActive,
+        ];
+        if ($correction) {
+            $row['correction'] = true;
+        }
+
+        return $row;
+    }
+
+    private function removeDir(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+        $items = scandir($directory) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $directory.'/'.$item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
静的サイト側に、公開中作品の伸びが見えるボードを足します。作品の識別子から順位を外し、URLが順位変動で壊れないようにしています。Laravel版（Blade）は廃止予定のため変更していません。

## 何が変わるか

- トップに「公開中」タブ、専用ページ `/now/`、RSS `/feed.xml` を追加
- 並び替え初期値は伸び額。1日ペース・累計・順位上昇・公開日でも並べ替え可能
- 前回発表からの伸び、1日あたりペース、順位変動、追い抜き、マイルストーン到達を表示
- ブラウザのローカルストレージで、前回訪問からの累計差も出す
- 作品ページURLは `/movies/tmdb-19995/` や `/movies/jp-tmdb-372058/` のように安定キーになる

## データの持ち方

永続データはリポジトリの `data/history/` です。CIのMySQLは毎回消える前提なので、生の観測値だけを追記します。伸び・ペース・順位は保存せず、エクスポート時に計算します。

- 世界: `tmdb-{id}`
- 日本（TMDBあり）: `jp-tmdb-{id}`
- 日本（なし）: `jp-{title+yearのハッシュ}`
- 後から TMDB が付いてもキーは変えない
- 興収が下がった観測は捨てず `correction: true`。伸び計算からは除外
- 取得件数が 150 未満なら、履歴もDBも更新しない
- Wikipedia上から消えた公開中作品は、履歴上も公開終了として閉じる

ボード対象は、上流の公開中フラグ、または直近30日で数字が動いた作品です。

## 旧URL

今回の範囲で直しています。

- 取得時点の旧ID（順位入り）をレジストリに残し、`dist/_redirects` で 301
- 世界の `/movies/001_19995/` 形式は 404 ページでも `tmdb-{id}` へ誘導
- 日本の `jp_{順位}_{hash}` は `legacy-map.json` で安定キーへ誘導

## 初回デプロイ後の見え方

履歴が1点しかない間は「伸び待ち」になります。Wikipediaの日本興収は配給発表ベースで、毎日は動きません。意味のある伸びが出るのは、数字が変わった発表が2回溜まってからです。

公開ワークフローは取得後に `data/history` を bot がコミットします。マージ後のスケジュール実行から観測が積み上がります。

## 確認したこと

- `tests/Unit/BoxOffice/BoxOfficeHistoryTest.php` 9件成功
- `npm run build` 成功

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffbd6-721d-7381-926e-7a9e3dee8586?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffbd6-721d-7381-926e-7a9e3dee8586&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

